### PR TITLE
Fix release verification script to work correctly with source release

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -139,11 +139,11 @@ fetch_archive() {
   import_gpg_keys
 
   local dist_name=$1
-  download_rc_file ${dist_name}.tar.gz
-  download_rc_file ${dist_name}.tar.gz.asc
-  download_rc_file ${dist_name}.tar.gz.sha512
-  gpg --verify ${dist_name}.tar.gz.asc ${dist_name}.tar.gz
-  ${sha512_verify} ${dist_name}.tar.gz.sha512
+  download_rc_file ${dist_name}-src.tar.gz
+  download_rc_file ${dist_name}-src.tar.gz.asc
+  download_rc_file ${dist_name}-src.tar.gz.sha512
+  gpg --verify ${dist_name}-src.tar.gz.asc ${dist_name}-src.tar.gz
+  ${sha512_verify} ${dist_name}-src.tar.gz.sha512
 }
 
 verify_dir_artifact_signatures() {
@@ -224,7 +224,7 @@ ensure_source_directory() {
     if [ ! -d "${SPATIALBENCH_SOURCE_DIR}" ]; then
       pushd $SPATIALBENCH_TMPDIR
       fetch_archive ${dist_name}
-      tar xf ${dist_name}.tar.gz
+      tar xf ${dist_name}-src.tar.gz
 
       popd
     fi


### PR DESCRIPTION
The artifacts released to dist.apache.org only contain source releases. See https://dist.apache.org/repos/dist/dev/sedona/sedona-spatialbench-0.1.0-rc1/ as an example. The files in the release directory are:

* `apache-sedona-spatialbench-0.1.0-src.tar.gz`
* `apache-sedona-spatialbench-0.1.0-src.tar.gz.asc`
* `apache-sedona-spatialbench-0.1.0-src.tar.sha512` (should be `apache-sedona-spatialbench-0.1.0-src.tar.gz.sha512`)

This patch adds "-src" suffix to the filenames of verified files. This will make it correctly verify 0.1.0-RC1 and outputs "Release candidate 0.1.0-RC1 looks good!".