### PR TITLE
spatial polars Q11 query fix

### DIFF
--- a/spatialbench-queries/spatial_polars.py
+++ b/spatialbench-queries/spatial_polars.py
@@ -523,23 +523,22 @@ def q11(data_paths: dict[str, str]) -> DataFrame:
     )
 
     return (
-        trip_df.spatial.join(
-            zone_df,
-            left_on="t_pickuploc",
-            right_on="z_boundary",
-            predicate="intersects",
-        )
-        .spatial.join(
-            zone_df,
-            left_on="t_dropoffloc",
-            right_on="z_boundary",
-            predicate="intersects",
+        zone_df.spatial.join(
+            zone_df.spatial.join(
+                trip_df,
+                how="inner",
+                left_on="z_boundary",
+                right_on="t_pickuploc",
+                predicate="contains",
+            ),
+            how="inner",
+            left_on="z_boundary",
+            right_on="t_dropoffloc",
+            predicate="contains",
             suffix="_dropoff",
-        )
-        .filter(
+        ).filter(
             pl.col("z_zonekey") != pl.col("z_zonekey_dropoff"),
-        )
-        .select(
+        ).select(
             pl.len().alias("cross_zone_trip_count"),
         )
     )


### PR DESCRIPTION
I knew that the Q11 query I created originally was dramatically slower than the sedonaDB results, but since I was getting the correct output I went with it.  

I've re-evaluated the implementation of Q11 for spatial polars, and realized that I can do inner joins starting with the zones being joined to the trips, instead of left joins starting with the trips. The result is that the spatial polars implementation will return the correct results ~7.5x faster than before.  It's still not sedonaDB speed 🚀 but I believe it should longer timeout in the github actions benchmark 😄 