### PR TITLE
feature: Add DuckDB and SedonaDB nightly support

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -317,8 +317,9 @@ jobs:
           echo "SEDONADB_VERSION: ${{ env.SEDONADB_VERSION }}"
           echo "========================================"
           if [ "${{ env.SEDONADB_NIGHTLY }}" = "true" ]; then
-            # Use Gemfury as primary index to ensure nightly version is installed
+            # Use Gemfury as primary index and --pre to install nightly alpha builds (e.g., 0.3.0a69)
             pip install "sedonadb[geopandas]" pandas pyarrow pyproj \
+              --pre \
               --index-url https://repo.fury.io/sedona-nightlies/ \
               --extra-index-url https://pypi.org/simple/
           elif [ -n "${{ env.SEDONADB_VERSION }}" ]; then

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -271,7 +271,7 @@ jobs:
           else
             pip install geopandas pandas pyarrow shapely
           fi
-          echo "Installed GeoPandas version: $(python -c 'from importlib.metadata import version; print(version(\"geopandas\"))')"
+          echo "Installed GeoPandas version: $(python -c 'from importlib.metadata import version; print(version("geopandas"))')"
       
       - name: Run GeoPandas benchmark
         run: |
@@ -373,7 +373,7 @@ jobs:
           else
             pip install "spatial-polars[knn]" pyarrow
           fi
-          echo "Installed Spatial Polars version: $(python -c 'from importlib.metadata import version; print(version(\"spatial-polars\"))')"
+          echo "Installed Spatial Polars version: $(python -c 'from importlib.metadata import version; print(version("spatial-polars"))')"
       
       - name: Run Spatial Polars benchmark
         run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -327,7 +327,7 @@ jobs:
           else
             pip install "sedonadb[geopandas]" pandas pyarrow pyproj
           fi
-          echo "Installed SedonaDB version: $(python -c 'from importlib.metadata import version; print(version(\"sedonadb\"))')"
+          echo "Installed SedonaDB version: $(python -c 'from importlib.metadata import version; print(version("sedonadb"))')"
       
       - name: Run SedonaDB benchmark
         run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -222,7 +222,11 @@ jobs:
       
       - name: Pre-install DuckDB spatial extension
         run: |
-          python -c "import duckdb; con = duckdb.connect(); con.execute('INSTALL spatial'); print('DuckDB spatial extension installed')"
+          if [ "${{ env.DUCKDB_NIGHTLY }}" = "true" ]; then
+            python -c "import duckdb; con = duckdb.connect(); con.execute('INSTALL spatial FROM core_nightly'); print('DuckDB spatial extension installed from core_nightly')"
+          else
+            python -c "import duckdb; con = duckdb.connect(); con.execute('INSTALL spatial'); print('DuckDB spatial extension installed')"
+          fi
       
       - name: Run DuckDB benchmark
         run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -68,6 +68,16 @@ on:
           - '1'
           - '3'
           - '5'
+      sedonadb_nightly:
+        description: 'Use SedonaDB nightly build from Gemfury (ignores version if true)'
+        required: false
+        default: true
+        type: boolean
+      duckdb_nightly:
+        description: 'Use DuckDB pre-release/nightly build (ignores version if true)'
+        required: false
+        default: true
+        type: boolean
 
 concurrency:
   group: ${{ github.repository }}-${{ github.ref }}-benchmark
@@ -84,6 +94,9 @@ env:
   DUCKDB_VERSION: ${{ github.event.inputs.duckdb_version }}
   GEOPANDAS_VERSION: ${{ github.event.inputs.geopandas_version }}
   SPATIAL_POLARS_VERSION: ${{ github.event.inputs.spatial_polars_version }}
+  # Nightly build options (default: true)
+  SEDONADB_NIGHTLY: ${{ github.event.inputs.sedonadb_nightly || 'true' }}
+  DUCKDB_NIGHTLY: ${{ github.event.inputs.duckdb_nightly || 'true' }}
   # Hugging Face dataset for benchmark data
   HF_DATASET: apache-sedona/spatialbench
   HF_DATA_VERSION: v0.1.0
@@ -194,7 +207,13 @@ jobs:
       
       - name: Install dependencies
         run: |
-          if [ -n "${{ env.DUCKDB_VERSION }}" ]; then
+          echo "=== DuckDB Installation Parameters ==="
+          echo "DUCKDB_NIGHTLY: ${{ env.DUCKDB_NIGHTLY }}"
+          echo "DUCKDB_VERSION: ${{ env.DUCKDB_VERSION }}"
+          echo "======================================"
+          if [ "${{ env.DUCKDB_NIGHTLY }}" = "true" ]; then
+            pip install duckdb --pre --upgrade pyarrow pandas
+          elif [ -n "${{ env.DUCKDB_VERSION }}" ]; then
             pip install "duckdb==${{ env.DUCKDB_VERSION }}" pyarrow pandas
           else
             pip install duckdb pyarrow pandas
@@ -290,7 +309,13 @@ jobs:
       
       - name: Install dependencies
         run: |
-          if [ -n "${{ env.SEDONADB_VERSION }}" ]; then
+          echo "=== SedonaDB Installation Parameters ==="
+          echo "SEDONADB_NIGHTLY: ${{ env.SEDONADB_NIGHTLY }}"
+          echo "SEDONADB_VERSION: ${{ env.SEDONADB_VERSION }}"
+          echo "========================================"
+          if [ "${{ env.SEDONADB_NIGHTLY }}" = "true" ]; then
+            pip install "sedonadb[geopandas]" pandas pyarrow pyproj --extra-index-url https://repo.fury.io/sedona-nightlies/
+          elif [ -n "${{ env.SEDONADB_VERSION }}" ]; then
             pip install "sedonadb[geopandas]==${{ env.SEDONADB_VERSION }}" pandas pyarrow pyproj
           else
             pip install "sedonadb[geopandas]" pandas pyarrow pyproj

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -212,8 +212,9 @@ jobs:
           echo "DUCKDB_VERSION: ${{ env.DUCKDB_VERSION }}"
           echo "======================================"
           if [ "${{ env.DUCKDB_NIGHTLY }}" = "true" ]; then
-            # Use 1.4 LTS nightly (duckdb<1.5.0) which has extensions available from core_nightly
-            pip install "duckdb<1.5.0" pyarrow pandas
+            # Use --pre to install pre-release dev builds (e.g., 1.4.4.dev48)
+            # Constraint <1.5.0 ensures we get 1.4.x dev builds which have extensions in core_nightly
+            pip install "duckdb<1.5.0" --pre pyarrow pandas
           elif [ -n "${{ env.DUCKDB_VERSION }}" ]; then
             pip install "duckdb==${{ env.DUCKDB_VERSION }}" pyarrow pandas
           else
@@ -319,7 +320,10 @@ jobs:
           echo "SEDONADB_VERSION: ${{ env.SEDONADB_VERSION }}"
           echo "========================================"
           if [ "${{ env.SEDONADB_NIGHTLY }}" = "true" ]; then
-            pip install "sedonadb[geopandas]" pandas pyarrow pyproj --extra-index-url https://repo.fury.io/sedona-nightlies/
+            # Use Gemfury as primary index to ensure nightly version is installed
+            pip install "sedonadb[geopandas]" pandas pyarrow pyproj \
+              --index-url https://repo.fury.io/sedona-nightlies/ \
+              --extra-index-url https://pypi.org/simple/
           elif [ -n "${{ env.SEDONADB_VERSION }}" ]; then
             pip install "sedonadb[geopandas]==${{ env.SEDONADB_VERSION }}" pandas pyarrow pyproj
           else

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -213,7 +213,7 @@ jobs:
           echo "======================================"
           if [ "${{ env.DUCKDB_NIGHTLY }}" = "true" ]; then
             # Use --pre to install pre-release dev builds (e.g., 1.4.4.dev48)
-            # Constraint <1.5.0 ensures we get 1.4.x dev builds which have extensions in core_nightly
+            # Constraint <1.5.0 ensures we get 1.4.x branch dev builds
             pip install "duckdb<1.5.0" --pre pyarrow pandas
           elif [ -n "${{ env.DUCKDB_VERSION }}" ]; then
             pip install "duckdb==${{ env.DUCKDB_VERSION }}" pyarrow pandas
@@ -224,11 +224,8 @@ jobs:
       
       - name: Pre-install DuckDB spatial extension
         run: |
-          if [ "${{ env.DUCKDB_NIGHTLY }}" = "true" ]; then
-            python -c "import duckdb; con = duckdb.connect(); con.execute('INSTALL spatial FROM core_nightly'); print('DuckDB spatial extension installed from core_nightly')"
-          else
-            python -c "import duckdb; con = duckdb.connect(); con.execute('INSTALL spatial'); print('DuckDB spatial extension installed')"
-          fi
+          # Dev builds don't have spatial extension in core_nightly, so always use default repo
+          python -c "import duckdb; con = duckdb.connect(); con.execute('INSTALL spatial'); print('DuckDB spatial extension installed')"
       
       - name: Run DuckDB benchmark
         run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -212,7 +212,8 @@ jobs:
           echo "DUCKDB_VERSION: ${{ env.DUCKDB_VERSION }}"
           echo "======================================"
           if [ "${{ env.DUCKDB_NIGHTLY }}" = "true" ]; then
-            pip install duckdb --pre --upgrade pyarrow pandas
+            # Use 1.4 LTS nightly (duckdb<1.5.0) which has extensions available from core_nightly
+            pip install "duckdb<1.5.0" pyarrow pandas
           elif [ -n "${{ env.DUCKDB_VERSION }}" ]; then
             pip install "duckdb==${{ env.DUCKDB_VERSION }}" pyarrow pandas
           else


### PR DESCRIPTION
This pull request updates the `benchmark.yml` GitHub Actions workflow to add support for installing and benchmarking against nightly/pre-release builds of SedonaDB and DuckDB. It introduces new workflow inputs and logic to control whether nightly builds are used, making it easier to test against the latest development versions of these dependencies.

Key changes include:

**Workflow Inputs and Environment Variables:**

* Added new boolean inputs `sedonadb_nightly` and `duckdb_nightly` to the workflow, allowing users to specify whether to use nightly builds for SedonaDB and DuckDB (defaulting to `true`). Corresponding environment variables are set for use in job steps. [[1]](diffhunk://#diff-aacbd0338bcf598920c120b69adaba2672acc7ea314cfca0f792bebe5fe2acd0R71-R80) [[2]](diffhunk://#diff-aacbd0338bcf598920c120b69adaba2672acc7ea314cfca0f792bebe5fe2acd0R97-R99)

**Dependency Installation Logic:**

* Updated the dependency installation steps for both DuckDB and SedonaDB to check the new nightly flags. If enabled, the workflow installs the latest nightly/pre-release builds using the appropriate package indexes and pip flags; otherwise, it falls back to installing the specified version or the latest stable. [[1]](diffhunk://#diff-aacbd0338bcf598920c120b69adaba2672acc7ea314cfca0f792bebe5fe2acd0L197-R218) [[2]](diffhunk://#diff-aacbd0338bcf598920c120b69adaba2672acc7ea314cfca0f792bebe5fe2acd0L293-R324)

**Documentation and Debugging:**

* Added echo statements to print out which version and nightly flags are being used for both DuckDB and SedonaDB, improving transparency and debugging in CI logs. [[1]](diffhunk://#diff-aacbd0338bcf598920c120b69adaba2672acc7ea314cfca0f792bebe5fe2acd0L197-R218) [[2]](diffhunk://#diff-aacbd0338bcf598920c120b69adaba2672acc7ea314cfca0f792bebe5fe2acd0L293-R324)

**DuckDB Spatial Extension:**

* Clarified that for DuckDB dev builds, the spatial extension is always installed from the default repository, since it's not included in nightly core builds.