### PR TITLE
[CI] Add Dependabot config for `github-actions` ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    open-pull-requests-limit: 2
+    schedule:
+      interval: monthly
+    groups:
+      github-dependencies:
+        patterns:
+          - '*'
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Basic config file with settings like the main Sedona repo

https://github.com/actions/checkout/releases/tag/v6.0.1

https://github.com/apache/sedona-spatialbench/blob/main/.github/workflows/benchmark.yml#L110