### PR TITLE
Prepare the project for 0.2.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://github.com/apache/sedona-spatialbench/"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/apache/sedona-spatialbench/"
-version = "0.1.0"
+version = "0.2.0"
 
 [workspace.dependencies]
 geo = "0.31.0"

--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -39,7 +39,7 @@ This will run all verification tests on your local checkout without requiring an
 To create a local tarball for testing:
 
 ```shell
-VERSION="0.1.0" && git archive HEAD --prefix=apache-sedona-spatialbench-${VERSION}/ | gzip > apache-sedona-spatialbench-${VERSION}-src.tar.gz
+VERSION="0.2.0" && git archive HEAD --prefix=apache-sedona-spatialbench-${VERSION}/ | gzip > apache-sedona-spatialbench-${VERSION}-src.tar.gz
 dev/release/verify-release-candidate.sh apache-sedona-spatialbench-${VERSION}-src.tar.gz
 ```
 
@@ -48,7 +48,7 @@ dev/release/verify-release-candidate.sh apache-sedona-spatialbench-${VERSION}-sr
 Once a release candidate has been uploaded to Apache dist, verify it using:
 
 ```shell
-dev/release/verify-release-candidate.sh 0.1.0 1
+dev/release/verify-release-candidate.sh 0.2.0 1
 ```
 
 This will download the release candidate from `https://dist.apache.org/repos/dist/dev/sedona/` and verify it.
@@ -77,16 +77,16 @@ a committer.
 
 ```shell
 git pull upstream main
-git branch -b branch-0.1.0
-git push upstream -u branch-0.1.0:branch-0.1.0
+git branch -b branch-0.2.0
+git push upstream -u branch-0.2.0:branch-0.2.0
 ```
 
 When the state of the `branch-x.x.x` branch is clean and checks are complete,
 the release candidate tag can be created:
 
 ```shell
-git tag -a sedona-spatialbench-0.1.0-rc1 -m "Tag Apache Sedona SpatialBench 0.1.0-rc1"
-git push upstream sedona-spatialbench-0.1.0-rc1
+git tag -a sedona-spatialbench-0.2.0-rc1 -m "Tag Apache Sedona SpatialBench 0.2.0-rc1"
+git push upstream sedona-spatialbench-0.2.0-rc1
 ```
 
 ### Signing Commands
@@ -120,7 +120,7 @@ dev/sedona directory of the Apache distribution SVN:
 
 ```shell
 # Set version and RC number variables
-SEDONA_VERSION="0.1.0"
+SEDONA_VERSION="0.2.0"
 RC_NUMBER="1"
 
 # Create the directory in SVN
@@ -154,7 +154,7 @@ are currently all derived from `Cargo.toml`, which can be updated to:
 
 ```
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 ```
 
 ## Publishing to crates.io

--- a/spatialbench-arrow/Cargo.toml
+++ b/spatialbench-arrow/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "spatialbench-arrow"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Apache Sedona <dev@sedona.apache.org>"]
 description = "SpatialBench data generator into Apache Arrow format"
@@ -30,7 +30,7 @@ categories = ["science::geo", "database", "data-structures"]
 
 [dependencies]
 arrow = { version = "56", default-features = false, features = ["prettyprint"] }
-spatialbench = { path = "../spatialbench", version = "0.1.0" }
+spatialbench = { path = "../spatialbench", version = "0.2.0" }
 geo = { workspace = true }
 geozero = { workspace = true }
 

--- a/spatialbench-cli/Cargo.toml
+++ b/spatialbench-cli/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "spatialbench-cli"
-version = "0.1.0"
+version = "0.2.0"
 authors = { workspace = true }
 description = "Blazing fast pure Rust SpatialBench data generator command line tool."
 readme = "README.md"
@@ -32,8 +32,8 @@ categories = ["science::geo", "database", "command-line-utilities", "development
 arrow = "56"
 parquet = "56"
 clap = { version = "4.5.32", features = ["derive"] }
-spatialbench = { path = "../spatialbench", version = "0.1.0"}
-spatialbench-arrow = { path = "../spatialbench-arrow", version = "0.1.0" }
+spatialbench = { path = "../spatialbench", version = "0.2.0"}
+spatialbench-arrow = { path = "../spatialbench-arrow", version = "0.2.0" }
 tokio = { version = "1.44.1", features = ["full"]}
 futures = "0.3.31"
 num_cpus = "1.0"


### PR DESCRIPTION
## Summary

Bump workspace version from 0.1.0 to 0.2.0 across all crates and update release documentation examples to reference 0.2.0.

### Changes

- `Cargo.toml`: workspace version → `0.2.0`
- `spatialbench-arrow/Cargo.toml`: crate version + `spatialbench` dep → `0.2.0`
- `spatialbench-cli/Cargo.toml`: crate version + `spatialbench` and `spatialbench-arrow` deps → `0.2.0`
- `dev/release/README.md`: update all example commands from `0.1.0` to `0.2.0`, update post-release version bump example to `0.3.0`

### Not changed (intentionally)

- `spatialbench/Cargo.toml` — inherits version from workspace, no change needed
- `.github/workflows/benchmark.yml` `HF_DATA_VERSION: v0.1.0` — refers to benchmark data version on HuggingFace, not the crate version