### PR TITLE
feat: add COG writer with Perlin noise pixel generation

### DIFF
--- a/spatialbench-raster/Cargo.toml
+++ b/spatialbench-raster/Cargo.toml
@@ -28,5 +28,14 @@ description = "Raster benchmark data generation for SpatialBench"
 keywords = ["spatial", "raster", "cog", "geotiff", "benchmark"]
 categories = ["science::geo", "data-structures"]
 
+[features]
+default = []
+cog-writer = ["dep:gdal"]
+
 [dependencies]
 spatialbench = { path = "../spatialbench", version = "0.3.0" }
+gdal = { version = "0.19", optional = true, features = ["bindgen"] }
+
+[dev-dependencies]
+gdal = { version = "0.19", features = ["bindgen"] }
+tempfile = "3"

--- a/spatialbench-raster/examples/bench_cog.rs
+++ b/spatialbench-raster/examples/bench_cog.rs
@@ -1,0 +1,143 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Benchmark: Perlin noise generation + COG writing.
+//!
+//! Usage: `cargo run --release -p spatialbench-raster --features cog-writer --example bench_cog`
+
+use spatialbench_raster::cog::{write_cog, CogConfig};
+use spatialbench_raster::footprint::{lon_to_utm_zone, lonlat_to_utm, utm_to_lonlat, Footprint};
+use spatialbench_raster::noise::PerlinNoise;
+
+use std::hint::black_box;
+use std::time::Instant;
+
+fn test_footprint() -> Footprint {
+    let lon = -100.0_f64;
+    let lat = 35.0_f64;
+    let zone = lon_to_utm_zone(lon);
+    let (e, n) = lonlat_to_utm(lon, lat, zone);
+    let step = 109_800.0;
+    let nw = utm_to_lonlat(e, n, zone, true);
+    let se = utm_to_lonlat(e + step, n - step, zone, true);
+    Footprint {
+        id: 0,
+        epsg: 32600 + zone,
+        origin: (e, n),
+        bbox_4326: [
+            nw.0.min(se.0),
+            nw.1.min(se.1),
+            nw.0.max(se.0),
+            nw.1.max(se.1),
+        ],
+    }
+}
+
+fn bench_noise_only() {
+    let iterations = 10u32;
+    let noise = PerlinNoise::new(42);
+    let mut buf = Vec::new();
+
+    // Warmup
+    noise.generate_raster_into(1830, 1830, 8.0, &mut buf);
+
+    let start = Instant::now();
+    for i in 0..iterations {
+        let n = PerlinNoise::new(i as u64);
+        n.generate_raster_into(1830, 1830, 8.0, &mut buf);
+        black_box(&buf);
+    }
+    let elapsed = start.elapsed();
+
+    let per_call = elapsed / iterations;
+    let pixels = 1830u64 * 1830;
+    let mpix_per_sec = (pixels as f64 / per_call.as_secs_f64()) / 1_000_000.0;
+
+    println!("=== Perlin noise generation (1830x1830, f32) ===");
+    println!("  {iterations} iterations in {elapsed:.2?}");
+    println!("  {per_call:.2?} per raster");
+    println!("  {mpix_per_sec:.1} Mpix/sec");
+    println!("  Buffer reuse: {:.1} MB", buf.capacity() as f64 / 1e6);
+}
+
+fn bench_cog_write() {
+    let iterations = 10u32;
+    let config = CogConfig::default();
+    let fp = test_footprint();
+    let dir = tempfile::tempdir().unwrap();
+
+    // Warmup
+    write_cog(&config, &fp, 999, &dir.path().join("warmup.tif")).unwrap();
+
+    let start = Instant::now();
+    for i in 0..iterations {
+        let path = dir.path().join(format!("{i:04}.tif"));
+        write_cog(&config, &fp, i, &path).unwrap();
+    }
+    let elapsed = start.elapsed();
+
+    let per_call = elapsed / iterations;
+    let file_size = std::fs::metadata(dir.path().join("0000.tif"))
+        .unwrap()
+        .len();
+
+    println!("\n=== Full COG write (noise + MEM + ZSTD + disk) ===");
+    println!("  {iterations} iterations in {elapsed:.2?}");
+    println!("  {per_call:.2?} per COG");
+    println!(
+        "  {:.1} COGs/sec",
+        iterations as f64 / elapsed.as_secs_f64()
+    );
+    println!("  File size: {:.1} KB", file_size as f64 / 1024.0);
+
+    // Breakdown: noise vs GDAL
+    let mut buf = Vec::new();
+    let noise_start = Instant::now();
+    for i in 0..iterations {
+        let n = PerlinNoise::new(i as u64);
+        n.generate_raster_into(1830, 1830, 8.0, &mut buf);
+        black_box(&buf);
+    }
+    let noise_elapsed = noise_start.elapsed();
+    let gdal_elapsed = elapsed - noise_elapsed;
+
+    println!("\n=== Breakdown ===");
+    println!(
+        "  Noise: {:.2?} ({:.0}%)",
+        noise_elapsed,
+        100.0 * noise_elapsed.as_secs_f64() / elapsed.as_secs_f64()
+    );
+    println!(
+        "  GDAL:  {:.2?} ({:.0}%)",
+        gdal_elapsed,
+        100.0 * gdal_elapsed.as_secs_f64() / elapsed.as_secs_f64()
+    );
+
+    // Extrapolate SF=1
+    let sf1_cogs: u64 = 1320 * 16;
+    let sf1_time = per_call.as_secs_f64() * sf1_cogs as f64;
+    println!("\n=== SF=1 projection (single-threaded) ===");
+    println!(
+        "  {sf1_cogs} COGs × {per_call:.2?} = {sf1_time:.0}s ({:.1} min)",
+        sf1_time / 60.0
+    );
+}
+
+fn main() {
+    bench_noise_only();
+    bench_cog_write();
+}

--- a/spatialbench-raster/src/cog/mod.rs
+++ b/spatialbench-raster/src/cog/mod.rs
@@ -46,7 +46,7 @@ pub struct CogConfig {
     /// Internal tile size (pixels per side).
     pub tile_size: u32,
     /// Perlin noise frequency (controls spatial detail per tile).
-    pub noise_frequency: f64,
+    pub noise_frequency: f32,
 }
 
 impl Default for CogConfig {

--- a/spatialbench-raster/src/cog/mod.rs
+++ b/spatialbench-raster/src/cog/mod.rs
@@ -23,7 +23,7 @@
 //! - 256×256 internal tiling
 //! - Perlin noise pixel data for realistic compression ratios
 
-use crate::footprint::Footprint;
+use crate::footprint::{Footprint, FootprintConfig};
 use crate::noise::PerlinNoise;
 
 use gdal::raster::RasterCreationOptions;
@@ -34,16 +34,17 @@ use std::io;
 use std::path::Path;
 
 /// Configuration for COG generation.
+///
+/// Wraps a [`FootprintConfig`] (which defines pixel dimensions and resolution)
+/// and adds COG-specific settings like internal tile size and noise frequency.
+/// This ensures footprint grid generation and COG writing always agree on
+/// raster dimensions.
 #[derive(Debug, Clone, Copy)]
 pub struct CogConfig {
-    /// Raster width in pixels.
-    pub width: u32,
-    /// Raster height in pixels.
-    pub height: u32,
+    /// Shared raster dimensions and resolution.
+    pub raster: FootprintConfig,
     /// Internal tile size (pixels per side).
     pub tile_size: u32,
-    /// Pixel resolution in meters (for geotransform).
-    pub resolution: f64,
     /// Perlin noise frequency (controls spatial detail per tile).
     pub noise_frequency: f64,
 }
@@ -51,9 +52,7 @@ pub struct CogConfig {
 impl Default for CogConfig {
     fn default() -> Self {
         Self {
-            width: 1830,
-            height: 1830,
-            resolution: 60.0,
+            raster: FootprintConfig::default(),
             tile_size: 256,
             noise_frequency: 8.0,
         }
@@ -80,6 +79,10 @@ pub fn write_cog(
     cog_id: u32,
     output_path: &Path,
 ) -> io::Result<()> {
+    let width = config.raster.cog_width;
+    let height = config.raster.cog_height;
+    let resolution = config.raster.resolution as f64;
+
     // Create in-memory dataset
     let mem_driver = DriverManager::get_driver_by_name("MEM").map_err(|e| {
         io::Error::new(
@@ -89,7 +92,7 @@ pub fn write_cog(
     })?;
 
     let mut mem_ds = mem_driver
-        .create_with_band_type::<u8, _>("", config.width as usize, config.height as usize, 1)
+        .create_with_band_type::<u8, _>("", width as usize, height as usize, 1)
         .map_err(|e| io::Error::other(format!("failed to create MEM dataset: {e}")))?;
 
     // Set CRS to footprint's UTM zone
@@ -106,11 +109,11 @@ pub fn write_cog(
     // Geotransform: origin is NW corner, positive x-res east, negative y-res south
     let gt: GeoTransform = [
         footprint.origin.0, // top-left x (easting)
-        config.resolution,  // pixel width (meters)
+        resolution,         // pixel width (meters)
         0.0,                // rotation
         footprint.origin.1, // top-left y (northing)
         0.0,                // rotation
-        -config.resolution, // pixel height (negative = south)
+        -resolution,        // pixel height (negative = south)
     ];
     mem_ds
         .set_geo_transform(&gt)
@@ -119,20 +122,17 @@ pub fn write_cog(
     // Generate pixel data with Perlin noise
     let seed = (footprint.id as u64) << 32 | cog_id as u64;
     let noise = PerlinNoise::new(seed);
-    let pixels = noise.generate_raster(config.width, config.height, config.noise_frequency);
+    let pixels = noise.generate_raster(width, height, config.noise_frequency);
 
-    // Write raster band
-    let mut band = mem_ds
-        .rasterband(1)
-        .map_err(|e| io::Error::other(format!("failed to get raster band: {e}")))?;
-    let mut buffer =
-        gdal::raster::Buffer::new((config.width as usize, config.height as usize), pixels);
-    band.write::<u8>(
-        (0, 0),
-        (config.width as usize, config.height as usize),
-        &mut buffer,
-    )
-    .map_err(|e| io::Error::other(format!("failed to write pixel data: {e}")))?;
+    // Write raster band (scoped to release mutable borrow on mem_ds)
+    {
+        let mut band = mem_ds
+            .rasterband(1)
+            .map_err(|e| io::Error::other(format!("failed to get raster band: {e}")))?;
+        let mut buffer = gdal::raster::Buffer::new((width as usize, height as usize), pixels);
+        band.write::<u8>((0, 0), (width as usize, height as usize), &mut buffer)
+            .map_err(|e| io::Error::other(format!("failed to write pixel data: {e}")))?;
+    }
 
     // Create COG via create_copy from the MEM dataset
     let cog_driver = DriverManager::get_driver_by_name("COG").map_err(|e| {
@@ -210,6 +210,19 @@ mod tests {
         assert!((gt[3] - fp.origin.1).abs() < 1e-6);
         assert!((gt[1] - 60.0).abs() < 1e-6);
         assert!((gt[5] - (-60.0)).abs() < 1e-6);
+
+        // Verify pixel data was written (not all zeros, has variation)
+        let band = ds.rasterband(1).unwrap();
+        let buf = band
+            .read_as::<u8>((0, 0), (w, h), (w as usize, h as usize), None)
+            .unwrap();
+        let pixels = buf.data();
+        let min = *pixels.iter().min().unwrap();
+        let max = *pixels.iter().max().unwrap();
+        assert!(
+            max - min > 50,
+            "expected pixel variation in COG, got range [{min}, {max}]"
+        );
     }
 
     #[test]

--- a/spatialbench-raster/src/cog/mod.rs
+++ b/spatialbench-raster/src/cog/mod.rs
@@ -146,6 +146,7 @@ pub fn write_cog(
         "COMPRESS=ZSTD",
         &format!("BLOCKSIZE={}", config.tile_size),
         "LEVEL=3",
+        "NUM_THREADS=ALL_CPUS",
     ]);
 
     mem_ds

--- a/spatialbench-raster/src/cog/mod.rs
+++ b/spatialbench-raster/src/cog/mod.rs
@@ -1,0 +1,246 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Cloud-Optimized GeoTIFF (COG) writer using GDAL.
+//!
+//! Generates single-band UInt8 COGs with:
+//! - Per-footprint UTM CRS (EPSG:326xx)
+//! - ZSTD compression
+//! - 256×256 internal tiling
+//! - Perlin noise pixel data for realistic compression ratios
+
+use crate::footprint::Footprint;
+use crate::noise::PerlinNoise;
+
+use gdal::raster::RasterCreationOptions;
+use gdal::spatial_ref::SpatialRef;
+use gdal::{DriverManager, GeoTransform};
+
+use std::io;
+use std::path::Path;
+
+/// Configuration for COG generation.
+#[derive(Debug, Clone, Copy)]
+pub struct CogConfig {
+    /// Raster width in pixels.
+    pub width: u32,
+    /// Raster height in pixels.
+    pub height: u32,
+    /// Internal tile size (pixels per side).
+    pub tile_size: u32,
+    /// Pixel resolution in meters (for geotransform).
+    pub resolution: f64,
+    /// Perlin noise frequency (controls spatial detail per tile).
+    pub noise_frequency: f64,
+}
+
+impl Default for CogConfig {
+    fn default() -> Self {
+        Self {
+            width: 1830,
+            height: 1830,
+            resolution: 60.0,
+            tile_size: 256,
+            noise_frequency: 8.0,
+        }
+    }
+}
+
+/// Write a single COG file for a given footprint and scene ID.
+///
+/// The output is a Cloud-Optimized GeoTIFF with:
+/// - Single band, UInt8, ZSTD compressed
+/// - CRS set to the footprint's UTM zone
+/// - Geotransform derived from the footprint's NW corner origin
+/// - Deterministic Perlin noise pixel data seeded from `(footprint.id, cog_id)`
+///
+/// Internally creates a MEM dataset, populates it, then uses the COG driver's
+/// `create_copy` to produce the final file (COG is a create-copy-only driver).
+///
+/// # Errors
+///
+/// Returns `io::Error` if GDAL fails to create the dataset or write raster data.
+pub fn write_cog(
+    config: &CogConfig,
+    footprint: &Footprint,
+    cog_id: u32,
+    output_path: &Path,
+) -> io::Result<()> {
+    // Create in-memory dataset
+    let mem_driver = DriverManager::get_driver_by_name("MEM").map_err(|e| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("GDAL MEM driver not available: {e}"),
+        )
+    })?;
+
+    let mut mem_ds = mem_driver
+        .create_with_band_type::<u8, _>("", config.width as usize, config.height as usize, 1)
+        .map_err(|e| io::Error::other(format!("failed to create MEM dataset: {e}")))?;
+
+    // Set CRS to footprint's UTM zone
+    let srs = SpatialRef::from_epsg(footprint.epsg).map_err(|e| {
+        io::Error::other(format!(
+            "failed to create SRS for EPSG:{}: {e}",
+            footprint.epsg
+        ))
+    })?;
+    mem_ds
+        .set_spatial_ref(&srs)
+        .map_err(|e| io::Error::other(format!("failed to set CRS: {e}")))?;
+
+    // Geotransform: origin is NW corner, positive x-res east, negative y-res south
+    let gt: GeoTransform = [
+        footprint.origin.0, // top-left x (easting)
+        config.resolution,  // pixel width (meters)
+        0.0,                // rotation
+        footprint.origin.1, // top-left y (northing)
+        0.0,                // rotation
+        -config.resolution, // pixel height (negative = south)
+    ];
+    mem_ds
+        .set_geo_transform(&gt)
+        .map_err(|e| io::Error::other(format!("failed to set geotransform: {e}")))?;
+
+    // Generate pixel data with Perlin noise
+    let seed = (footprint.id as u64) << 32 | cog_id as u64;
+    let noise = PerlinNoise::new(seed);
+    let pixels = noise.generate_raster(config.width, config.height, config.noise_frequency);
+
+    // Write raster band
+    let mut band = mem_ds
+        .rasterband(1)
+        .map_err(|e| io::Error::other(format!("failed to get raster band: {e}")))?;
+    let mut buffer =
+        gdal::raster::Buffer::new((config.width as usize, config.height as usize), pixels);
+    band.write::<u8>(
+        (0, 0),
+        (config.width as usize, config.height as usize),
+        &mut buffer,
+    )
+    .map_err(|e| io::Error::other(format!("failed to write pixel data: {e}")))?;
+
+    // Create COG via create_copy from the MEM dataset
+    let cog_driver = DriverManager::get_driver_by_name("COG").map_err(|e| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("GDAL COG driver not available: {e}"),
+        )
+    })?;
+
+    let cog_options = RasterCreationOptions::from_iter([
+        "COMPRESS=ZSTD",
+        &format!("BLOCKSIZE={}", config.tile_size),
+        "LEVEL=3",
+    ]);
+
+    mem_ds
+        .create_copy(&cog_driver, output_path, &cog_options)
+        .map_err(|e| io::Error::other(format!("failed to create COG: {e}")))?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::footprint::{lon_to_utm_zone, lonlat_to_utm, utm_to_lonlat};
+
+    use gdal::Dataset;
+    use tempfile::tempdir;
+
+    fn test_footprint() -> Footprint {
+        let lon = -100.0_f64;
+        let lat = 35.0_f64;
+        let zone = lon_to_utm_zone(lon);
+        let (e, n) = lonlat_to_utm(lon, lat, zone);
+        let step = 109_800.0;
+        let nw = utm_to_lonlat(e, n, zone, true);
+        let se = utm_to_lonlat(e + step, n - step, zone, true);
+        Footprint {
+            id: 0,
+            epsg: 32600 + zone,
+            origin: (e, n),
+            bbox_4326: [
+                nw.0.min(se.0),
+                nw.1.min(se.1),
+                nw.0.max(se.0),
+                nw.1.max(se.1),
+            ],
+        }
+    }
+
+    #[test]
+    fn cog_roundtrip_default_config() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.tif");
+        let config = CogConfig::default();
+        let fp = test_footprint();
+
+        write_cog(&config, &fp, 0, &path).unwrap();
+
+        // Verify with GDAL
+        let ds = Dataset::open(&path).unwrap();
+        let (w, h) = ds.raster_size();
+        assert_eq!(w, 1830);
+        assert_eq!(h, 1830);
+        assert_eq!(ds.raster_count(), 1);
+
+        // Verify CRS
+        let srs = ds.spatial_ref().unwrap();
+        assert_eq!(srs.auth_code().unwrap(), fp.epsg as i32);
+
+        // Verify geotransform
+        let gt = ds.geo_transform().unwrap();
+        assert!((gt[0] - fp.origin.0).abs() < 1e-6);
+        assert!((gt[3] - fp.origin.1).abs() < 1e-6);
+        assert!((gt[1] - 60.0).abs() < 1e-6);
+        assert!((gt[5] - (-60.0)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn cog_deterministic() {
+        let dir = tempdir().unwrap();
+        let config = CogConfig::default();
+        let fp = test_footprint();
+
+        let path_a = dir.path().join("a.tif");
+        let path_b = dir.path().join("b.tif");
+        write_cog(&config, &fp, 7, &path_a).unwrap();
+        write_cog(&config, &fp, 7, &path_b).unwrap();
+
+        let a = std::fs::read(&path_a).unwrap();
+        let b = std::fs::read(&path_b).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn cog_different_seeds_differ() {
+        let dir = tempdir().unwrap();
+        let config = CogConfig::default();
+        let fp = test_footprint();
+
+        let path_a = dir.path().join("a.tif");
+        let path_b = dir.path().join("b.tif");
+        write_cog(&config, &fp, 0, &path_a).unwrap();
+        write_cog(&config, &fp, 1, &path_b).unwrap();
+
+        let a = std::fs::read(&path_a).unwrap();
+        let b = std::fs::read(&path_b).unwrap();
+        assert_ne!(a, b);
+    }
+}

--- a/spatialbench-raster/src/lib.rs
+++ b/spatialbench-raster/src/lib.rs
@@ -17,10 +17,13 @@
 
 //! Raster benchmark data generation for SpatialBench.
 //!
-//! This crate provides the data model, scaling tables, footprint grid, and
-//! topology factoring logic for the SpatialBench raster benchmark. COG writing
-//! (Phase 1b) and STAC catalog generation are in separate crates.
+//! This crate provides the data model, scaling tables, footprint grid,
+//! topology factoring, and COG writing logic for the SpatialBench raster
+//! benchmark.
 
+#[cfg(feature = "cog-writer")]
+pub mod cog;
 pub mod footprint;
+pub mod noise;
 pub mod scaling;
 pub mod topology;

--- a/spatialbench-raster/src/noise/mod.rs
+++ b/spatialbench-raster/src/noise/mod.rs
@@ -86,19 +86,33 @@ impl PerlinNoise {
     ///
     /// `width` and `height` are pixel dimensions. `frequency` controls the
     /// spatial scale of the noise (higher = more detail per tile).
-    /// Returns a row-major buffer of `width * height` bytes.
-    pub fn generate_raster(&self, width: u32, height: u32, frequency: f64) -> Vec<u8> {
+    /// Writes into `buf`, resizing it to `width * height` bytes (row-major).
+    /// Passing a pre-allocated buffer avoids repeated heap allocations when
+    /// generating many COGs (see [`BufferRecycler`] pattern in spatialbench).
+    pub fn generate_raster_into(&self, width: u32, height: u32, frequency: f64, buf: &mut Vec<u8>) {
         let len = width as usize * height as usize;
-        let mut buf = Vec::with_capacity(len);
+        buf.clear();
+        buf.reserve(len.saturating_sub(buf.capacity()));
+        let inv_w = frequency / width as f64;
+        let inv_h = frequency / height as f64;
         for row in 0..height {
+            let y = row as f64 * inv_h;
             for col in 0..width {
-                let x = col as f64 * frequency / width as f64;
-                let y = row as f64 * frequency / height as f64;
+                let x = col as f64 * inv_w;
                 // Sample returns [-1, 1], map to [0, 255]
                 let val = (self.sample(x, y) + 1.0) * 0.5;
                 buf.push((val.clamp(0.0, 1.0) * 255.0) as u8);
             }
         }
+    }
+
+    /// Generate a full raster buffer of UInt8 pixel values.
+    ///
+    /// Convenience wrapper around [`Self::generate_raster_into`] that allocates
+    /// a new buffer. Prefer `generate_raster_into` in hot loops.
+    pub fn generate_raster(&self, width: u32, height: u32, frequency: f64) -> Vec<u8> {
+        let mut buf = Vec::new();
+        self.generate_raster_into(width, height, frequency, &mut buf);
         buf
     }
 }

--- a/spatialbench-raster/src/noise/mod.rs
+++ b/spatialbench-raster/src/noise/mod.rs
@@ -23,6 +23,10 @@
 //!
 //! The implementation follows Ken Perlin's improved noise (2002) with a
 //! permutation table seeded deterministically from a footprint/COG ID pair.
+//!
+//! Uses `f32` arithmetic for ~2x throughput on ARM NEON (Apple Silicon, AWS
+//! Graviton). The 23-bit mantissa is more than sufficient for mapping to
+//! UInt8 pixel values.
 
 /// A seeded 2D Perlin noise generator.
 ///
@@ -59,7 +63,7 @@ impl PerlinNoise {
 
     /// Sample noise at (x, y), returning a value in [-1.0, 1.0].
     #[inline]
-    pub fn sample(&self, x: f64, y: f64) -> f64 {
+    pub fn sample(&self, x: f32, y: f32) -> f32 {
         let xi = x.floor() as i32;
         let yi = y.floor() as i32;
         let xf = x - x.floor();
@@ -89,19 +93,49 @@ impl PerlinNoise {
     /// Writes into `buf`, resizing it to `width * height` bytes (row-major).
     /// Passing a pre-allocated buffer avoids repeated heap allocations when
     /// generating many COGs (see [`BufferRecycler`] pattern in spatialbench).
-    pub fn generate_raster_into(&self, width: u32, height: u32, frequency: f64, buf: &mut Vec<u8>) {
+    ///
+    /// Row-level y-axis values are hoisted out of the inner loop: the integer
+    /// grid cell, fractional offset, fade curve, and permutation lookups for
+    /// each row are computed once and reused across all columns.
+    pub fn generate_raster_into(&self, width: u32, height: u32, frequency: f32, buf: &mut Vec<u8>) {
         let len = width as usize * height as usize;
         buf.clear();
         buf.reserve(len.saturating_sub(buf.capacity()));
-        let inv_w = frequency / width as f64;
-        let inv_h = frequency / height as f64;
+        let inv_w = frequency / width as f32;
+        let inv_h = frequency / height as f32;
+
         for row in 0..height {
-            let y = row as f64 * inv_h;
+            let y = row as f32 * inv_h;
+
+            // Hoist row-invariant y-axis computations
+            let yi_raw = y.floor() as i32;
+            let yf = y - y.floor();
+            let v = fade(yf);
+            let yi = (yi_raw & 255) as usize;
+
             for col in 0..width {
-                let x = col as f64 * inv_w;
-                // Sample returns [-1, 1], map to [0, 255]
-                let val = (self.sample(x, y) + 1.0) * 0.5;
-                buf.push((val.clamp(0.0, 1.0) * 255.0) as u8);
+                let x = col as f32 * inv_w;
+                let xi_raw = x.floor() as i32;
+                let xf = x - x.floor();
+                let u = fade(xf);
+                let xi = (xi_raw & 255) as usize;
+
+                // Hash corners (yi and yi+1 are row-constant)
+                let p_xi = self.perm[xi] as usize;
+                let p_xi1 = self.perm[xi + 1] as usize;
+                let aa = self.perm[p_xi + yi] as usize;
+                let ab = self.perm[p_xi + yi + 1] as usize;
+                let ba = self.perm[p_xi1 + yi] as usize;
+                let bb = self.perm[p_xi1 + yi + 1] as usize;
+
+                // Gradient dot products and bilinear interpolation
+                let x1 = lerp(grad(aa, xf, yf), grad(ba, xf - 1.0, yf), u);
+                let x2 = lerp(grad(ab, xf, yf - 1.0), grad(bb, xf - 1.0, yf - 1.0), u);
+                let val = lerp(x1, x2, v);
+
+                // Map [-1, 1] → [0, 255]
+                let pixel = ((val + 1.0) * 0.5).clamp(0.0, 1.0) * 255.0;
+                buf.push(pixel as u8);
             }
         }
     }
@@ -110,7 +144,7 @@ impl PerlinNoise {
     ///
     /// Convenience wrapper around [`Self::generate_raster_into`] that allocates
     /// a new buffer. Prefer `generate_raster_into` in hot loops.
-    pub fn generate_raster(&self, width: u32, height: u32, frequency: f64) -> Vec<u8> {
+    pub fn generate_raster(&self, width: u32, height: u32, frequency: f32) -> Vec<u8> {
         let mut buf = Vec::new();
         self.generate_raster_into(width, height, frequency, &mut buf);
         buf
@@ -127,19 +161,19 @@ fn lcg_next(state: u64) -> u64 {
 
 /// Fade curve: 6t^5 - 15t^4 + 10t^3 (Perlin's improved noise, 2002).
 #[inline]
-fn fade(t: f64) -> f64 {
+fn fade(t: f32) -> f32 {
     t * t * t * (t * (t * 6.0 - 15.0) + 10.0)
 }
 
 /// Linear interpolation.
 #[inline]
-fn lerp(a: f64, b: f64, t: f64) -> f64 {
+fn lerp(a: f32, b: f32, t: f32) -> f32 {
     a + t * (b - a)
 }
 
 /// Gradient function using hash to select from 4 directions.
 #[inline]
-fn grad(hash: usize, x: f64, y: f64) -> f64 {
+fn grad(hash: usize, x: f32, y: f32) -> f32 {
     match hash & 3 {
         0 => x + y,
         1 => -x + y,
@@ -157,8 +191,8 @@ mod tests {
         let n1 = PerlinNoise::new(42);
         let n2 = PerlinNoise::new(42);
         for i in 0..100 {
-            let x = i as f64 * 0.1;
-            let y = i as f64 * 0.07;
+            let x = i as f32 * 0.1;
+            let y = i as f32 * 0.07;
             assert_eq!(n1.sample(x, y).to_bits(), n2.sample(x, y).to_bits());
         }
     }
@@ -169,7 +203,7 @@ mod tests {
         let n2 = PerlinNoise::new(1);
         let mut differ = false;
         for i in 0..100 {
-            let x = i as f64 * 0.1;
+            let x = i as f32 * 0.1;
             if n1.sample(x, 0.5) != n2.sample(x, 0.5) {
                 differ = true;
                 break;
@@ -182,11 +216,11 @@ mod tests {
     fn output_range() {
         let n = PerlinNoise::new(123);
         for i in 0..1000 {
-            let x = i as f64 * 0.037;
-            let y = i as f64 * 0.053;
+            let x = i as f32 * 0.037;
+            let y = i as f32 * 0.053;
             let val = n.sample(x, y);
             assert!(
-                val >= -1.0 && val <= 1.0,
+                (-1.0..=1.0).contains(&val),
                 "sample out of range: {val} at ({x}, {y})"
             );
         }

--- a/spatialbench-raster/src/noise/mod.rs
+++ b/spatialbench-raster/src/noise/mod.rs
@@ -1,0 +1,200 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! 2D Perlin noise generator for deterministic raster pixel generation.
+//!
+//! Produces spatially correlated UInt8 pixel values that mimic the spectral
+//! characteristics of real satellite imagery, yielding realistic compression
+//! ratios (~2-4x with DEFLATE/ZSTD).
+//!
+//! The implementation follows Ken Perlin's improved noise (2002) with a
+//! permutation table seeded deterministically from a footprint/COG ID pair.
+
+/// A seeded 2D Perlin noise generator.
+///
+/// Each instance produces a unique but deterministic noise field based on its
+/// seed. The permutation table is shuffled via a simple LCG seeded from the
+/// input, ensuring reproducibility across runs.
+pub struct PerlinNoise {
+    perm: [u8; 512],
+}
+
+impl PerlinNoise {
+    /// Create a new Perlin noise generator with a deterministic seed.
+    ///
+    /// Typical usage: `seed = (footprint_id as u64) << 32 | cog_id as u64`
+    pub fn new(seed: u64) -> Self {
+        let mut perm = [0u8; 512];
+        // Initialize identity permutation
+        for i in 0..256u16 {
+            perm[i as usize] = i as u8;
+        }
+        // Fisher-Yates shuffle with LCG
+        let mut rng = seed;
+        for i in (1..256usize).rev() {
+            rng = lcg_next(rng);
+            let j = (rng >> 16) as usize % (i + 1);
+            perm.swap(i, j);
+        }
+        // Duplicate for wrapping
+        for i in 0..256 {
+            perm[256 + i] = perm[i];
+        }
+        Self { perm }
+    }
+
+    /// Sample noise at (x, y), returning a value in [-1.0, 1.0].
+    #[inline]
+    pub fn sample(&self, x: f64, y: f64) -> f64 {
+        let xi = x.floor() as i32;
+        let yi = y.floor() as i32;
+        let xf = x - x.floor();
+        let yf = y - y.floor();
+
+        let u = fade(xf);
+        let v = fade(yf);
+
+        // Hash corners
+        let xi = (xi & 255) as usize;
+        let yi = (yi & 255) as usize;
+        let aa = self.perm[self.perm[xi] as usize + yi] as usize;
+        let ab = self.perm[self.perm[xi] as usize + yi + 1] as usize;
+        let ba = self.perm[self.perm[xi + 1] as usize + yi] as usize;
+        let bb = self.perm[self.perm[xi + 1] as usize + yi + 1] as usize;
+
+        // Gradient dot products and bilinear interpolation
+        let x1 = lerp(grad(aa, xf, yf), grad(ba, xf - 1.0, yf), u);
+        let x2 = lerp(grad(ab, xf, yf - 1.0), grad(bb, xf - 1.0, yf - 1.0), u);
+        lerp(x1, x2, v)
+    }
+
+    /// Generate a full raster buffer of UInt8 pixel values.
+    ///
+    /// `width` and `height` are pixel dimensions. `frequency` controls the
+    /// spatial scale of the noise (higher = more detail per tile).
+    /// Returns a row-major buffer of `width * height` bytes.
+    pub fn generate_raster(&self, width: u32, height: u32, frequency: f64) -> Vec<u8> {
+        let len = width as usize * height as usize;
+        let mut buf = Vec::with_capacity(len);
+        for row in 0..height {
+            for col in 0..width {
+                let x = col as f64 * frequency / width as f64;
+                let y = row as f64 * frequency / height as f64;
+                // Sample returns [-1, 1], map to [0, 255]
+                let val = (self.sample(x, y) + 1.0) * 0.5;
+                buf.push((val.clamp(0.0, 1.0) * 255.0) as u8);
+            }
+        }
+        buf
+    }
+}
+
+/// Simple LCG for permutation table shuffling (Numerical Recipes constants).
+#[inline]
+fn lcg_next(state: u64) -> u64 {
+    state
+        .wrapping_mul(6_364_136_223_846_793_005)
+        .wrapping_add(1)
+}
+
+/// Fade curve: 6t^5 - 15t^4 + 10t^3 (Perlin's improved noise, 2002).
+#[inline]
+fn fade(t: f64) -> f64 {
+    t * t * t * (t * (t * 6.0 - 15.0) + 10.0)
+}
+
+/// Linear interpolation.
+#[inline]
+fn lerp(a: f64, b: f64, t: f64) -> f64 {
+    a + t * (b - a)
+}
+
+/// Gradient function using hash to select from 4 directions.
+#[inline]
+fn grad(hash: usize, x: f64, y: f64) -> f64 {
+    match hash & 3 {
+        0 => x + y,
+        1 => -x + y,
+        2 => x - y,
+        _ => -x - y,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deterministic_output() {
+        let n1 = PerlinNoise::new(42);
+        let n2 = PerlinNoise::new(42);
+        for i in 0..100 {
+            let x = i as f64 * 0.1;
+            let y = i as f64 * 0.07;
+            assert_eq!(n1.sample(x, y).to_bits(), n2.sample(x, y).to_bits());
+        }
+    }
+
+    #[test]
+    fn different_seeds_differ() {
+        let n1 = PerlinNoise::new(0);
+        let n2 = PerlinNoise::new(1);
+        let mut differ = false;
+        for i in 0..100 {
+            let x = i as f64 * 0.1;
+            if n1.sample(x, 0.5) != n2.sample(x, 0.5) {
+                differ = true;
+                break;
+            }
+        }
+        assert!(differ, "different seeds should produce different noise");
+    }
+
+    #[test]
+    fn output_range() {
+        let n = PerlinNoise::new(123);
+        for i in 0..1000 {
+            let x = i as f64 * 0.037;
+            let y = i as f64 * 0.053;
+            let val = n.sample(x, y);
+            assert!(
+                val >= -1.0 && val <= 1.0,
+                "sample out of range: {val} at ({x}, {y})"
+            );
+        }
+    }
+
+    #[test]
+    fn generate_raster_correct_size() {
+        let n = PerlinNoise::new(7);
+        let buf = n.generate_raster(64, 64, 4.0);
+        assert_eq!(buf.len(), 64 * 64);
+    }
+
+    #[test]
+    fn generate_raster_has_variation() {
+        let n = PerlinNoise::new(99);
+        let buf = n.generate_raster(128, 128, 8.0);
+        let min = *buf.iter().min().unwrap();
+        let max = *buf.iter().max().unwrap();
+        // With Perlin noise at this frequency, we expect meaningful range
+        assert!(
+            max - min > 50,
+            "expected pixel variation, got range [{min}, {max}]"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Adds Perlin noise module for deterministic, spatially correlated UInt8 pixel generation (realistic ~2-4x compression ratios)
- Adds GDAL-based COG writer behind `cog-writer` feature flag using MEM→COG `create_copy` workflow
- Single-band, ZSTD compressed, 256×256 internal tiling, per-footprint UTM CRS

## Stacked on
- #98

## Test plan
- 24 tests passing: noise determinism/range/variation + COG roundtrip/determinism/uniqueness
- `cargo clippy -- -D warnings` clean
- `cargo fmt --check` clean