### PR TITLE
[CI] Remove deprecated hook `check-docstring-first`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,9 +37,6 @@ repos:
       - id: check-case-conflict
         name: run check-case-conflict
         description: check for case conflicts in file names
-      - id: check-docstring-first
-        name: run check-docstring-first
-        description: check that docstrings are at the start of functions
       - id: check-executables-have-shebangs
         name: run check-executables-have-shebangs
         description: check that executable scripts have shebang lines


### PR DESCRIPTION
https://github.com/pre-commit/pre-commit-hooks#deprecated--replaced-hooks