### PR TITLE
[DOCS] Set site_url so language switcher links include the base path

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ extra:
 
 
 site_name: SpatialBench
+site_url: https://sedona.apache.org/spatialbench/
 site_description: SpatialBench is a benchmark for assessing geospatial SQL analytics query performance across database systems
 # Define a reusable block of links with a YAML anchor (&)
 


### PR DESCRIPTION
Fixes #109

## What changes were proposed in this PR?

Add `site_url: https://sedona.apache.org/spatialbench/` to `mkdocs.yml`.

Without `site_url`, the `mkdocs-static-i18n` plugin generates the header language-switcher links rooted at the domain, so the 中文 option pointed to `https://sedona.apache.org/zh/` (404) instead of `https://sedona.apache.org/spatialbench/zh/`. Setting `site_url` also makes Material emit correct `<link rel="canonical">` tags and sitemap URLs.

## How was this patch tested?

Built the docs locally with the full plugin stack and inspected the generated HTML:

- The language switcher now links to `/spatialbench/` (English) and `/spatialbench/zh/` (中文) on both the English and Chinese pages.
- Canonical links now appear, pointing at `https://sedona.apache.org/spatialbench/` and `https://sedona.apache.org/spatialbench/zh/`.