### PR TITLE
Install Rust toolchain with rustup to fix Rust workflow startup failure

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,11 +34,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # @stable
-        with:
-          components: rustfmt, clippy
-          toolchain: stable
+      - name: Use stable Rust
+        run: |
+          rustup toolchain install stable --no-self-update
+          rustup default stable
+          rustup component add rustfmt clippy
       - uses: Swatinem/rust-cache@v2
         with:
           # Update this key to force a new cache
@@ -55,9 +55,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # @stable
-        with:
-          toolchain: stable
+      - name: Use stable Rust
+        run: |
+          rustup toolchain install stable --no-self-update
+          rustup default stable
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "rust-test-tests-spatialbench-v1"
@@ -68,9 +69,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # @stable
-        with:
-          toolchain: stable
+      - name: Use stable Rust
+        run: |
+          rustup toolchain install stable --no-self-update
+          rustup default stable
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "rust-test-doc-spatialbench-v1"
@@ -81,9 +83,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # @stable
-        with:
-          toolchain: stable
+      - name: Use stable Rust
+        run: |
+          rustup toolchain install stable --no-self-update
+          rustup default stable
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "rust-test-all-spatialbench-arrow-v1"
@@ -94,9 +97,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # @stable
-        with:
-          toolchain: stable
+      - name: Use stable Rust
+        run: |
+          rustup toolchain install stable --no-self-update
+          rustup default stable
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "rust-test-all-spatialbench-cli-v1"
@@ -108,9 +112,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # @stable
-        with:
-          toolchain: stable
+      - name: Use stable Rust
+        run: |
+          rustup toolchain install stable --no-self-update
+          rustup default stable
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "rust-docs-v1"
@@ -166,10 +171,11 @@ jobs:
           mc alias set local http://localhost:9000 minioadmin minioadmin
           mc mb local/spatialbench-test
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # @stable
-        with:
-          toolchain: stable
+      - name: Use stable Rust
         if: steps.changes.outputs.s3 == 'true'
+        run: |
+          rustup toolchain install stable --no-self-update
+          rustup default stable
 
       - uses: Swatinem/rust-cache@v2
         if: steps.changes.outputs.s3 == 'true'


### PR DESCRIPTION
## Problem

The **Rust** workflow has failed at **startup on every run since 2026-07-01** (main included) — GitHub blocks it before any job starts, reporting the generic *"This run likely failed because of a workflow file issue."* It's not a code or test failure, and no PR can make the check pass.

Root cause: **`dtolnay/rust-toolchain` is not on the ASF GitHub Actions allowlist**, so the run is blocked at startup. Evidence:
- Fails identically on every ref; last success was 2026-07-01 (when the allowlist evidently tightened).
- The repo's other workflows are fine: `benchmark.yml` uses only `actions/*`, and `pre-commit.yml`'s `j178/prek-action` is allowlisted.
- The sibling **apache/sedona-db** Rust CI is green and **does not use `dtolnay/rust-toolchain`** — it installs the toolchain with `rustup`, while still using `Swatinem/rust-cache@v2` (so that one *is* allowlisted).

## Fix

Mirror sedona-db: install the toolchain with `rustup` in a `run:` step, drop `dtolnay/rust-toolchain`, keep everything else (including `Swatinem/rust-cache`).

```yaml
- name: Use stable Rust
  run: |
    rustup toolchain install stable --no-self-update
    rustup default stable
    rustup component add rustfmt clippy   # lint job only
```

`rustup` is preinstalled on `ubuntu-latest`, so this is a drop-in replacement across all jobs (lint / tests / docs / S3 integration). No other changes; the S3 job keeps its `if: steps.changes.outputs.s3 == 'true'` guard.

This turns the Rust check green across the repo.
