### PR TITLE
Add geography variants of the SpatialBench queries

### DIFF
--- a/docs/geography-queries.md
+++ b/docs/geography-queries.md
@@ -1,0 +1,555 @@
+---
+title: Geography Queries
+---
+
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Run the SpatialBench Geography Queries
+
+
+SpatialBench's [main query suite](https://sedona.apache.org/spatialbench/queries/) is a **geometry** benchmark: the WKB columns are
+decoded with `ST_GeomFromWKB`, predicates use planar (2D Euclidean) edges, and every distance
+threshold is an angle in degrees.
+
+This notebook defines the **geography** counterpart of the same 12 queries. The data is
+unchanged — the same EPSG:4326 longitude/latitude WKB columns — but the columns are decoded
+with `ST_GeogFromWKB`, so edges are interpreted as geodesics on a sphere and every measure
+comes back in real-world units.
+
+## Why a second suite
+
+The geometry suite has to fake real-world units. It filters trips "within 50 km" of Sedona
+using `ST_DWithin(..., 0.45)`, converts metres to degrees with `1 m = 0.000009 degree`, and
+reports building overlap areas in square degrees.
+
+A degree of latitude is roughly 111 km everywhere, but a degree of longitude shrinks with the
+cosine of the latitude. So `0.45` degrees is about 50 km tall and only about 41 km wide at
+Sedona (34.87°N), and about 25 km wide at 60°N. Since SpatialBench data is generated across
+eight continent-sized boxes spanning latitudes −56° to 78°, a degree-based radius is a
+different real-world shape in every part of the dataset.
+
+The geography suite replaces all of that with metres and square metres:
+
+| | Geometry suite | Geography suite |
+|---|---|---|
+| Point/polygon constructor | `ST_GeomFromWKB`, `ST_GeomFromText` | `ST_GeogFromWKB`, `ST_GeogFromWKT` |
+| Edge interpretation | straight lines in a plane | geodesics on a sphere |
+| `ST_DWithin` threshold | degrees (`0.45`, `0.045`, `0.0045`) | metres (`50000`, `5000`, `500`) |
+| `ST_Distance`, `ST_Length` | degrees | metres |
+| `ST_Area` | square degrees | square metres |
+| Unit conversion in SQL | `/ 0.000009` | none needed |
+
+!!! note "The two suites are not row-for-row comparable"
+
+    A 0.45° planar radius and a 50 000 m geodesic radius select different trips, so Q1
+    returns a different 100 rows in each suite. That is the point of the exercise, not a
+    discrepancy: each suite has its own ground truth, and results should only ever be
+    compared within a suite.
+
+## The query module
+
+The same SQL is available outside this notebook from the query module, which prints the suite
+for a given dialect:
+
+```bash
+python3 spatialbench-queries/print_geography_queries.py SedonaDB
+```
+
+Running the queries needs an engine with a `GEOGRAPHY` type whose measures are geodesic;
+support for the individual functions is still filling in across engines, so check your
+engine's own reference for what it implements. Q12 is defined below but is not carried in the
+module and is not executed here: it is a K-nearest-neighbour join, and `ST_KNN` has no
+geography form yet.
+
+
+## Before you start
+
+
+
+```python
+%pip install -r ~/sedona-spatialbench/docs/requirements.txt
+
+```
+
+Additionally, install the SpatialBench CLI and generate the synthetic data on your machine:
+
+```
+# SpatialBench CLI
+cargo install --path ./spatialbench-cli
+# Generate the benchmarking data to the sf1-parquet directory
+spatialbench-cli -s 1 --format=parquet --output-dir sf1-parquet
+```
+
+Alternatively, download pre-generated data from [Hugging Face](https://huggingface.co/datasets/apache-sedona/spatialbench) instead of generating it (tables are published under `v<version>/sf<scale>/`; scale factors `sf0.1`, `sf1`, `sf10`, `sf100`):
+
+```
+pip install huggingface-hub
+hf download apache-sedona/spatialbench --repo-type dataset --include "v0.1.0/sf1/**" --local-dir spatialbench-data
+```
+
+If you use the Hugging Face download, set `DATA_DIR = "spatialbench-data/v0.1.0/sf1"` in the data-loading cell below.
+
+
+
+```python
+import sedona.db
+
+```
+
+
+```python
+sd = sedona.db.connect()
+
+```
+
+
+```python
+import os
+
+# The CLI writes flat files to sf1-parquet/; the Hugging Face download puts
+# partitioned tables under spatialbench-data/v0.1.0/sf1/. Point DATA_DIR at
+# whichever you used -- both layouts load below.
+DATA_DIR = "../sf1-parquet"
+
+for table in ["building", "customer", "driver", "trip", "vehicle", "zone"]:
+    flat = f"{DATA_DIR}/{table}.parquet"
+    source = flat if os.path.exists(flat) else f"{DATA_DIR}/{table}/*.parquet"
+    sd.read_parquet(source).to_view(table)
+
+```
+
+## Q1: Find trips starting within 50km of Sedona city center, ordered by distance
+
+**Real-life scenario:** Identify and rank trips by proximity to a city center for urban
+planning and transportation analysis.
+
+Unlike the geometry version, the 50 km radius is a true geodesic radius rather than a 0.45°
+angular one, and `distance_to_center` is in metres.
+
+**Spatial query characteristics tested:**
+
+1. Geodesic distance-based spatial filtering (`ST_DWithin`, metres)
+2. Geodesic distance calculation to a fixed point
+3. Coordinate extraction (`ST_X`, `ST_Y`)
+4. Ordering by spatial distance
+
+
+
+```python
+sd.sql("""
+SELECT
+    t.t_tripkey,
+    -- A point's coordinates are identical under either edge interpretation, so the lon/lat
+    -- projection stays on the geometry accessor, which is the more widely available one.
+    ST_X(ST_GeomFromWKB(t.t_pickuploc)) AS pickup_lon,
+    ST_Y(ST_GeomFromWKB(t.t_pickuploc)) AS pickup_lat,
+    t.t_pickuptime,
+    ST_Distance(
+        ST_GeogFromWKB(t.t_pickuploc),
+        ST_GeogFromWKT('POINT (-111.7610 34.8697)')
+    ) AS distance_to_center -- metres
+FROM trip t
+WHERE ST_DWithin(
+    ST_GeogFromWKB(t.t_pickuploc),
+    ST_GeogFromWKT('POINT (-111.7610 34.8697)'),
+    50000 -- 50 km geodesic radius around Sedona center
+)
+ORDER BY distance_to_center ASC, t.t_tripkey ASC
+LIMIT 100 -- Return only the 100 closest trips (bounded result set)
+""").show(3)
+
+```
+
+## Q2: Count trips starting within Coconino County
+
+**Real-life scenario:** Count trip activity inside an administrative boundary.
+
+The county polygon comes from Overture data with planar edges; reading it as a geography
+reinterprets those edges as geodesics, which can move the boundary by a few metres relative
+to the geometry suite and change the count for pickups that fall essentially on the border.
+
+**Spatial query characteristics tested:**
+
+1. Point-in-polygon spatial predicate on the sphere (`ST_Intersects`)
+2. Scalar subquery producing the query geography
+
+
+
+```python
+sd.sql("""
+SELECT COUNT(*) AS trip_count_in_coconino_county
+FROM trip t
+WHERE ST_Intersects(
+    ST_GeogFromWKB(t.t_pickuploc),
+    (SELECT ST_GeogFromWKB(z.z_boundary) FROM zone z WHERE z.z_name = 'Coconino County' LIMIT 1)
+)
+""").show(3)
+
+```
+
+## Q3: Monthly trip statistics for a buffered box around Sedona city center
+
+**Real-life scenario:** Track monthly demand, revenue and trip duration in a metro area.
+
+The polygon literal is the same ring as in the geometry suite, but its edges are geodesics
+here, so it is a spherical quadrilateral rather than a planar box.
+
+The ring is centred on Sedona and spans roughly **26.5 km east–west by 30 km north–south** —
+about 13 km and 15 km from the centre along each axis, with the corners ~20 km out. The 5 000 m
+buffer extends that to about 25 km at the corners.
+
+**Spatial query characteristics tested:**
+
+1. Geodesic buffered-polygon filtering (`ST_DWithin`, metres)
+2. Temporal grouping with `DATE_TRUNC`
+3. Multiple aggregations over a spatial filter
+
+
+
+```python
+sd.sql("""
+SELECT
+    DATE_TRUNC('month', t.t_pickuptime) AS pickup_month,
+    COUNT(t.t_tripkey) AS total_trips,
+    AVG(t.t_distance) AS avg_distance,
+    AVG(t.t_dropofftime - t.t_pickuptime) AS avg_duration,
+    AVG(t.t_fare) AS avg_fare
+FROM trip t
+WHERE ST_DWithin(
+    ST_GeogFromWKB(t.t_pickuploc),
+    -- ~26.5 km E-W by ~30 km N-S about the center; corners sit ~20 km out
+    ST_GeogFromWKT('POLYGON((-111.9060 34.7347, -111.6160 34.7347, -111.6160 35.0047, -111.9060 35.0047, -111.9060 34.7347))'),
+    5000 -- Additional 5 km geodesic buffer, so ~25 km at the corners
+)
+GROUP BY pickup_month
+ORDER BY pickup_month
+""").show(3)
+
+```
+
+## Q4: Zone distribution of top 1000 trips by tip amount
+
+**Real-life scenario:** Find which neighbourhoods generate the most generous tips.
+
+**Spatial query characteristics tested:**
+
+1. Point-in-polygon spatial join on the sphere (`ST_Within`)
+2. Spatial join against a `LIMIT`-bounded subquery
+3. Aggregation on the spatial join result
+
+
+
+```python
+sd.sql("""
+SELECT z.z_zonekey, z.z_name, COUNT(*) AS trip_count
+FROM zone z
+JOIN (
+    SELECT t.t_pickuploc
+    FROM trip t
+    ORDER BY t.t_tip DESC, t.t_tripkey ASC
+    LIMIT 1000 -- Replace 1000 with x (how many top tips you want)
+) top_trips
+ON ST_Within(ST_GeogFromWKB(top_trips.t_pickuploc), ST_GeogFromWKB(z.z_boundary))
+GROUP BY z.z_zonekey, z.z_name
+ORDER BY trip_count DESC, z.z_zonekey ASC
+""").show(3)
+
+```
+
+## Q5: Monthly travel patterns for repeat customers
+
+**Real-life scenario:** Measure how large an area each frequent customer travels across in a
+month, from the convex hull of their dropoff locations.
+
+In the geography suite `monthly_travel_hull_area` is a spherical area in square metres, and
+the hull itself is computed with geodesic edges.
+
+**Spatial query characteristics tested:**
+
+1. Geography aggregation into a collection (`ST_Collect_Agg`)
+2. Spherical convex hull (`ST_ConvexHull`)
+3. Spherical area (`ST_Area`, m²)
+4. Grouped aggregation with `HAVING`
+
+
+
+```python
+sd.sql("""
+SELECT
+    c.c_custkey,
+    c.c_name AS customer_name,
+    DATE_TRUNC('month', t.t_pickuptime) AS pickup_month,
+    ST_Area(ST_ConvexHull(ST_Collect_Agg(ST_GeogFromWKB(t.t_dropoffloc)))) AS monthly_travel_hull_area, -- m^2
+    COUNT(*) AS dropoff_count
+FROM trip t
+JOIN customer c ON t.t_custkey = c.c_custkey
+GROUP BY c.c_custkey, c.c_name, pickup_month
+HAVING dropoff_count > 5 -- Only include repeat customers for meaningful hulls
+ORDER BY monthly_travel_hull_area DESC, c.c_custkey ASC, pickup_month ASC
+LIMIT 100 -- Return only the top 100 repeat customer-months by travel-hull area (bounded result set)
+""").show(3)
+
+```
+
+## Q6: Zone statistics for trips intersecting a bounding box
+
+**Real-life scenario:** Summarise trip activity for every zone touching a region of interest.
+
+**Spatial query characteristics tested:**
+
+1. Two spatial predicates in one join (`ST_Intersects` and `ST_Within`)
+2. Polygon-polygon intersection test on the sphere
+3. Aggregation over a doubly-filtered join
+
+
+
+```python
+sd.sql("""
+SELECT
+    z.z_zonekey, z.z_name,
+    COUNT(t.t_tripkey) AS total_pickups,
+    AVG(t.t_distance) AS avg_distance,
+    AVG(t.t_dropofftime - t.t_pickuptime) AS avg_duration
+FROM trip t, zone z
+WHERE ST_Intersects(
+        ST_GeogFromWKT('POLYGON((-112.2110 34.4197, -111.3110 34.4197, -111.3110 35.3197, -112.2110 35.3197, -112.2110 34.4197))'),
+        ST_GeogFromWKB(z.z_boundary)
+    )
+  AND ST_Within(ST_GeogFromWKB(t.t_pickuploc), ST_GeogFromWKB(z.z_boundary))
+GROUP BY z.z_zonekey, z.z_name
+ORDER BY total_pickups DESC, z.z_zonekey ASC
+""").show(3)
+
+```
+
+## Q7: Detect potential route detours
+
+**Real-life scenario:** Flag trips whose reported distance greatly exceeds the straight-line
+distance between pickup and dropoff, a signal for detours or fare padding.
+
+This is the query the geography type helps most. The geometry version measures a planar line
+length in degrees and divides by `0.000009` to pretend it is metres; the geography version
+measures the geodesic directly, so `line_distance_m` and `detour_ratio` are meaningful
+everywhere in the dataset rather than only near the equator.
+
+**Spatial query characteristics tested:**
+
+1. Line construction from two points (`ST_MakeLine`)
+2. Geodesic length (`ST_Length`, metres)
+3. Ratio computation with division-by-zero guarding
+
+
+
+```python
+sd.sql("""
+WITH trip_lengths AS (
+    SELECT
+        t.t_tripkey,
+        t.t_distance AS reported_distance_m,
+        ST_Length(
+            ST_MakeLine(
+                ST_GeogFromWKB(t.t_pickuploc),
+                ST_GeogFromWKB(t.t_dropoffloc)
+            )
+        ) AS line_distance_m -- metres, no degree conversion needed
+    FROM trip t
+)
+SELECT
+    t.t_tripkey,
+    t.reported_distance_m,
+    t.line_distance_m,
+    t.reported_distance_m / NULLIF(t.line_distance_m, 0) AS detour_ratio
+FROM trip_lengths t
+ORDER BY detour_ratio DESC NULLS LAST, reported_distance_m DESC, t_tripkey ASC
+LIMIT 100 -- Return only the top 100 highest-detour trips (bounded result set)
+""").show(3)
+
+```
+
+## Q8: Count nearby pickups for each building within a 500m radius
+
+**Real-life scenario:** Find the buildings that generate the most pickup activity.
+
+The 500 m radius is a true geodesic distance from the building footprint, so the catchment is
+the same physical size for a building in Norway as for one in Kenya — unlike the geometry
+suite, where `0.0045°` is a much narrower band at high latitude.
+
+**Spatial query characteristics tested:**
+
+1. Geodesic distance spatial join between points and polygons (`ST_DWithin`, metres)
+2. Aggregation on spatial join result
+
+
+
+```python
+sd.sql("""
+SELECT b.b_buildingkey, b.b_name, COUNT(*) AS nearby_pickup_count
+FROM trip t
+JOIN building b
+ON ST_DWithin(ST_GeogFromWKB(t.t_pickuploc), ST_GeogFromWKB(b.b_boundary), 500) -- 500 m geodesic
+GROUP BY b.b_buildingkey, b.b_name
+ORDER BY nearby_pickup_count DESC, b.b_buildingkey ASC
+LIMIT 100 -- Return only the top 100 busiest buildings (bounded result set)
+""").show(3)
+
+```
+
+## Q9: Building Conflation (duplicate/overlap detection via IoU)
+
+**Real-life scenario:** Detect duplicate or overlapping building footprints to find data
+quality issues.
+
+`area1`, `area2` and `overlap_area` are square metres here rather than square degrees, which
+makes them directly interpretable. `iou` is a ratio of areas, so it is dimensionless in both
+suites — though the values still differ, because the ratio of spherical areas is not the ratio
+of planar ones.
+
+**Spatial query characteristics tested:**
+
+1. Polygon-polygon self-join with a spatial predicate (`ST_Intersects`)
+2. Spherical overlay (`ST_Intersection`)
+3. Spherical area (`ST_Area`, m²)
+
+
+
+```python
+sd.sql("""
+WITH b1 AS (
+    SELECT b_buildingkey AS id, ST_GeogFromWKB(b_boundary) AS geog FROM building
+),
+b2 AS (
+    SELECT b_buildingkey AS id, ST_GeogFromWKB(b_boundary) AS geog FROM building
+),
+pairs AS (
+    SELECT
+        b1.id AS building_1,
+        b2.id AS building_2,
+        ST_Area(b1.geog) AS area1,        -- m^2
+        ST_Area(b2.geog) AS area2,        -- m^2
+        ST_Area(ST_Intersection(b1.geog, b2.geog)) AS overlap_area -- m^2
+    FROM b1
+    JOIN b2 ON b1.id < b2.id AND ST_Intersects(b1.geog, b2.geog)
+)
+SELECT
+    building_1,
+    building_2,
+    area1,
+    area2,
+    overlap_area,
+    CASE
+        WHEN overlap_area = 0 THEN 0.0
+        WHEN (area1 + area2 - overlap_area) = 0 THEN 1.0
+        ELSE overlap_area / (area1 + area2 - overlap_area)
+    END AS iou
+FROM pairs
+ORDER BY iou DESC, building_1 ASC, building_2 ASC
+LIMIT 100 -- Return only the top 100 most-overlapping building pairs (bounded result set)
+""").show(3)
+
+```
+
+## Q10: Zone statistics for trips starting within each zone
+
+**Real-life scenario:** Rank zones by average trip duration, keeping zones with no trips.
+
+**Spatial query characteristics tested:**
+
+1. Left spatial join on the sphere (`ST_Within`), preserving unmatched zones
+2. Aggregation with `NULL` handling in the ordering
+
+
+
+```python
+sd.sql("""
+SELECT
+    z.z_zonekey,
+    z.z_name AS pickup_zone,
+    AVG(t.t_dropofftime - t.t_pickuptime) AS avg_duration,
+    AVG(t.t_distance) AS avg_distance,
+    COUNT(t.t_tripkey) AS num_trips
+FROM zone z
+LEFT JOIN trip t ON ST_Within(ST_GeogFromWKB(t.t_pickuploc), ST_GeogFromWKB(z.z_boundary))
+GROUP BY z.z_zonekey, z.z_name
+ORDER BY avg_duration DESC NULLS LAST, z.z_zonekey ASC
+LIMIT 100 -- Return only the top 100 zones by average trip duration (bounded result set)
+""").show(3)
+
+```
+
+## Q11: Count trips that cross between different zones
+
+**Real-life scenario:** Quantify inter-zone travel demand for transit planning.
+
+**Spatial query characteristics tested:**
+
+1. Two independent point-in-polygon spatial joins on the sphere
+2. Non-spatial filter on the join result
+
+
+
+```python
+sd.sql("""
+SELECT COUNT(*) AS cross_zone_trip_count
+FROM trip t
+JOIN zone pickup_zone ON ST_Within(ST_GeogFromWKB(t.t_pickuploc), ST_GeogFromWKB(pickup_zone.z_boundary))
+JOIN zone dropoff_zone ON ST_Within(ST_GeogFromWKB(t.t_dropoffloc), ST_GeogFromWKB(dropoff_zone.z_boundary))
+WHERE pickup_zone.z_zonekey != dropoff_zone.z_zonekey
+""").show(3)
+
+```
+
+## Q12: Rank trip pickups by average distance to their 5 nearest buildings
+
+**Real-life scenario:** Find the most isolated pickups — those farthest from any surrounding
+building — for coverage and service-gap analysis.
+
+`avg_distance_to_5_nearest` is in metres, and the neighbour ranking itself is by geodesic
+distance rather than planar degrees, so the "5 nearest buildings" are genuinely the 5 nearest
+on the ground.
+
+**Spatial query characteristics tested:**
+
+1. K-nearest-neighbour spatial join on the sphere (`ST_KNN`)
+2. Geodesic point-to-polygon distance (`ST_Distance`, metres)
+3. Aggregation over the KNN result
+
+
+```sql
+WITH trip_with_geog AS (
+    SELECT t_tripkey, ST_GeogFromWKB(t_pickuploc) AS pickup_geog
+    FROM trip
+),
+building_with_geog AS (
+    SELECT ST_GeogFromWKB(b_boundary) AS boundary_geog
+    FROM building
+),
+knn AS (
+    SELECT
+        t.t_tripkey,
+        ST_Distance(t.pickup_geog, b.boundary_geog) AS distance_to_building -- metres
+    FROM trip_with_geog t
+    JOIN building_with_geog b ON ST_KNN(t.pickup_geog, b.boundary_geog, 5, TRUE) -- TRUE = rank by spherical distance
+)
+SELECT
+    t_tripkey,
+    AVG(distance_to_building) AS avg_distance_to_5_nearest
+FROM knn
+GROUP BY t_tripkey
+ORDER BY avg_distance_to_5_nearest DESC, t_tripkey ASC
+LIMIT 100 -- Return only the top 100 most-isolated pickups (bounded result set)
+```

--- a/docs/geography-queries.zh.md
+++ b/docs/geography-queries.zh.md
@@ -1,0 +1,524 @@
+---
+title: 地理查询
+---
+
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# 运行 SpatialBench 地理查询
+
+SpatialBench 的[主查询套件](https://sedona.apache.org/spatialbench/zh/queries/)是一个 **geometry（几何）** 基准：WKB 列通过
+`ST_GeomFromWKB` 解码，谓词使用平面（二维欧几里得）边，所有距离阈值都是以度为单位的角度。
+
+本笔记本定义这同样 12 条查询的 **geography（地理）** 版本。数据本身没有变化——仍是同样的
+EPSG:4326 经纬度 WKB 列——但列改用 `ST_GeogFromWKB` 解码，因此边被解释为球面上的大地线，
+所有度量结果都以真实世界的单位返回。
+
+## 为什么需要第二套查询
+
+geometry 套件不得不伪造真实世界的单位。它用 `ST_DWithin(..., 0.45)` 筛选 Sedona “50 公里内”
+的行程，用 `1 米 = 0.000009 度` 把米换算成度，并以平方度报告建筑物的重叠面积。
+
+一个纬度差大致在各处都约等于 111 公里，但一个经度差会随纬度的余弦而缩小。因此在 Sedona
+（北纬 34.87°），`0.45` 度约为 50 公里高、却只有约 41 公里宽；在北纬 60° 处仅约 25 公里宽。
+由于 SpatialBench 的数据生成在八个大陆级别的范围框内、跨越南纬 56° 到北纬 78°，以度为基准的
+半径在数据集的每个区域都对应着不同的真实形状。
+
+geography 套件把这些全部替换为米和平方米：
+
+| | geometry 套件 | geography 套件 |
+|---|---|---|
+| 点/面构造函数 | `ST_GeomFromWKB`、`ST_GeomFromText` | `ST_GeogFromWKB`、`ST_GeogFromWKT` |
+| 边的解释 | 平面上的直线 | 球面上的大地线 |
+| `ST_DWithin` 阈值 | 度（`0.45`、`0.045`、`0.0045`） | 米（`50000`、`5000`、`500`） |
+| `ST_Distance`、`ST_Length` | 度 | 米 |
+| `ST_Area` | 平方度 | 平方米 |
+| SQL 中的单位换算 | `/ 0.000009` | 无需换算 |
+
+!!! note "两套查询的结果无法逐行比较"
+
+    0.45° 的平面半径与 50 000 米的大地线半径会选出不同的行程，因此 Q1 在两套查询中返回的
+    是不同的 100 行。这正是本套件的意义所在，而不是结果不一致：每套查询都有各自的标准答案，
+    结果只应在同一套件内部进行比较。
+
+## 查询模块
+
+在本笔记本之外，也可以通过查询模块获取同样的 SQL，它会按指定方言打印整套查询：
+
+```bash
+python3 spatialbench-queries/print_geography_queries.py SedonaDB
+```
+
+运行这些查询需要一个具备 `GEOGRAPHY` 类型、且其度量基于大地线的引擎——各引擎对具体函数的支持
+仍在逐步完善，请查阅所用引擎自身的参考文档以确认其实现范围。Q12 在下文中给出了定义，但未纳入
+该模块，也不会在此执行：它是一个 K 最近邻连接，而 `ST_KNN` 目前还没有 geography 形式。
+
+## 在开始之前
+
+在运行此笔记本前，请确保已安装 `requirements.txt` 中列出的依赖：
+
+
+```python
+%pip install -r ~/sedona-spatialbench/docs/requirements.txt
+```
+
+    ...
+    ...
+    Note: you may need to restart the kernel to use updated packages.
+
+
+此外，请安装 SpatialBench CLI 并在本机生成合成数据：
+
+```
+# SpatialBench CLI
+cargo install --path ./spatialbench-cli
+# 将基准测试数据生成到 sf1-parquet 目录
+spatialbench-cli -s 1 --format=parquet --output-dir sf1-parquet
+```
+
+或者，你也可以从 [Hugging Face](https://huggingface.co/datasets/apache-sedona/spatialbench) 下载预生成的数据，而无需自行生成（数据表按 `v<版本>/sf<规模>/` 组织；提供 `sf0.1`、`sf1`、`sf10`、`sf100`）：
+
+```
+pip install huggingface-hub
+hf download apache-sedona/spatialbench --repo-type dataset --include "v0.1.0/sf1/**" --local-dir spatialbench-data
+```
+
+如果使用 Hugging Face 下载的数据，请在下方的数据加载单元格中设置 `DATA_DIR = "spatialbench-data/v0.1.0/sf1"`。
+
+
+```python
+import sedona.db
+```
+
+
+```python
+sd = sedona.db.connect()
+```
+
+
+```python
+import os
+
+# The CLI writes flat files to sf1-parquet/; the Hugging Face download puts
+# partitioned tables under spatialbench-data/v0.1.0/sf1/. Point DATA_DIR at
+# whichever you used -- both layouts load below.
+DATA_DIR = "../sf1-parquet"
+
+for table in ["building", "customer", "driver", "trip", "vehicle", "zone"]:
+    flat = f"{DATA_DIR}/{table}.parquet"
+    source = flat if os.path.exists(flat) else f"{DATA_DIR}/{table}/*.parquet"
+    sd.read_parquet(source).to_view(table)
+```
+
+## Q1：查找从 Sedona 市中心 50 公里范围内出发的行程，并按距离排序
+
+**实际场景：** 按照与市中心的距离识别并排序行程，用于城市规划与交通分析。
+
+与 geometry 版本不同，这里的 50 公里是真正的大地线半径，而不是 0.45° 的角度半径，且
+`distance_to_center` 以米为单位。
+
+**所考察的空间查询特性：**
+
+1. 基于大地线距离的空间过滤（`ST_DWithin`，米）
+2. 到固定点的大地线距离计算
+3. 坐标提取（`ST_X`、`ST_Y`）
+4. 按空间距离排序
+
+
+```python
+sd.sql("""
+SELECT
+    t.t_tripkey,
+    -- A point's coordinates are identical under either edge interpretation, so the lon/lat
+    -- projection stays on the geometry accessor, which is the more widely available one.
+    ST_X(ST_GeomFromWKB(t.t_pickuploc)) AS pickup_lon,
+    ST_Y(ST_GeomFromWKB(t.t_pickuploc)) AS pickup_lat,
+    t.t_pickuptime,
+    ST_Distance(
+        ST_GeogFromWKB(t.t_pickuploc),
+        ST_GeogFromWKT('POINT (-111.7610 34.8697)')
+    ) AS distance_to_center -- metres
+FROM trip t
+WHERE ST_DWithin(
+    ST_GeogFromWKB(t.t_pickuploc),
+    ST_GeogFromWKT('POINT (-111.7610 34.8697)'),
+    50000 -- 50 km geodesic radius around Sedona center
+)
+ORDER BY distance_to_center ASC, t.t_tripkey ASC
+LIMIT 100 -- Return only the 100 closest trips (bounded result set)
+""").show(3)
+
+```
+
+## Q2：统计从 Coconino County 出发的行程数
+
+**实际场景：** 统计某一行政边界内的行程活动。
+
+县级多边形来自 Overture 数据，其边为平面边；将它作为 geography 读取会把这些边重新解释为
+大地线，相对 geometry 套件可能使边界偏移几米，从而改变那些几乎正好落在边界上的上车点的计数。
+
+**所考察的空间查询特性：**
+
+1. 球面上的点在多边形内谓词（`ST_Intersects`）
+2. 由标量子查询产生查询用 geography
+
+
+```python
+sd.sql("""
+SELECT COUNT(*) AS trip_count_in_coconino_county
+FROM trip t
+WHERE ST_Intersects(
+    ST_GeogFromWKB(t.t_pickuploc),
+    (SELECT ST_GeogFromWKB(z.z_boundary) FROM zone z WHERE z.z_name = 'Coconino County' LIMIT 1)
+)
+""").show(3)
+
+```
+
+## Q3：Sedona 市中心周边带缓冲区范围的每月行程统计
+
+**实际场景：** 跟踪某都市区每月的需求、收入与行程时长。
+
+多边形字面量与 geometry 套件中的环相同，但这里它的边是大地线，因此它是一个球面四边形而不是
+平面矩形。
+
+该环以 Sedona 为中心，东西向约 **26.5 公里**、南北向约 **30 公里**——沿两个方向距中心分别约
+13 公里与 15 公里，四角约在 20 公里处。再加上 5 000 米缓冲后，四角处可达约 25 公里。
+
+**所考察的空间查询特性：**
+
+1. 基于大地线的多边形缓冲过滤（`ST_DWithin`，米）
+2. 使用 `DATE_TRUNC` 的时间分组
+3. 在空间过滤结果上进行多项聚合
+
+
+```python
+sd.sql("""
+SELECT
+    DATE_TRUNC('month', t.t_pickuptime) AS pickup_month,
+    COUNT(t.t_tripkey) AS total_trips,
+    AVG(t.t_distance) AS avg_distance,
+    AVG(t.t_dropofftime - t.t_pickuptime) AS avg_duration,
+    AVG(t.t_fare) AS avg_fare
+FROM trip t
+WHERE ST_DWithin(
+    ST_GeogFromWKB(t.t_pickuploc),
+    -- ~26.5 km E-W by ~30 km N-S about the center; corners sit ~20 km out
+    ST_GeogFromWKT('POLYGON((-111.9060 34.7347, -111.6160 34.7347, -111.6160 35.0047, -111.9060 35.0047, -111.9060 34.7347))'),
+    5000 -- Additional 5 km geodesic buffer, so ~25 km at the corners
+)
+GROUP BY pickup_month
+ORDER BY pickup_month
+""").show(3)
+
+```
+
+## Q4：小费最高的 1000 次行程的区域分布
+
+**实际场景：** 找出小费最丰厚的街区。
+
+**所考察的空间查询特性：**
+
+1. 球面上的点在多边形内空间连接（`ST_Within`）
+2. 与 `LIMIT` 限定子查询的空间连接
+3. 在空间连接结果上进行聚合
+
+
+```python
+sd.sql("""
+SELECT z.z_zonekey, z.z_name, COUNT(*) AS trip_count
+FROM zone z
+JOIN (
+    SELECT t.t_pickuploc
+    FROM trip t
+    ORDER BY t.t_tip DESC, t.t_tripkey ASC
+    LIMIT 1000 -- Replace 1000 with x (how many top tips you want)
+) top_trips
+ON ST_Within(ST_GeogFromWKB(top_trips.t_pickuploc), ST_GeogFromWKB(z.z_boundary))
+GROUP BY z.z_zonekey, z.z_name
+ORDER BY trip_count DESC, z.z_zonekey ASC
+""").show(3)
+
+```
+
+## Q5：回头客的每月出行范围
+
+**实际场景：** 通过下车点的凸包，衡量每位高频乘客在一个月内的出行覆盖范围有多大。
+
+在 geography 套件中，`monthly_travel_hull_area` 是以平方米为单位的球面面积，且凸包本身也是
+用大地线边计算的。
+
+**所考察的空间查询特性：**
+
+1. geography 聚合为集合（`ST_Collect_Agg`）
+2. 球面凸包（`ST_ConvexHull`）
+3. 球面面积（`ST_Area`，平方米）
+4. 带 `HAVING` 的分组聚合
+
+
+```python
+sd.sql("""
+SELECT
+    c.c_custkey,
+    c.c_name AS customer_name,
+    DATE_TRUNC('month', t.t_pickuptime) AS pickup_month,
+    ST_Area(ST_ConvexHull(ST_Collect_Agg(ST_GeogFromWKB(t.t_dropoffloc)))) AS monthly_travel_hull_area, -- m^2
+    COUNT(*) AS dropoff_count
+FROM trip t
+JOIN customer c ON t.t_custkey = c.c_custkey
+GROUP BY c.c_custkey, c.c_name, pickup_month
+HAVING dropoff_count > 5 -- Only include repeat customers for meaningful hulls
+ORDER BY monthly_travel_hull_area DESC, c.c_custkey ASC, pickup_month ASC
+LIMIT 100 -- Return only the top 100 repeat customer-months by travel-hull area (bounded result set)
+""").show(3)
+
+```
+
+## Q6：与某一范围框相交的区域的行程统计
+
+**实际场景：** 汇总所有与目标区域接触的区域的行程活动。
+
+**所考察的空间查询特性：**
+
+1. 在一次连接中使用两个空间谓词（`ST_Intersects` 与 `ST_Within`）
+2. 球面上的多边形-多边形相交判断
+3. 在双重过滤的连接结果上进行聚合
+
+
+```python
+sd.sql("""
+SELECT
+    z.z_zonekey, z.z_name,
+    COUNT(t.t_tripkey) AS total_pickups,
+    AVG(t.t_distance) AS avg_distance,
+    AVG(t.t_dropofftime - t.t_pickuptime) AS avg_duration
+FROM trip t, zone z
+WHERE ST_Intersects(
+        ST_GeogFromWKT('POLYGON((-112.2110 34.4197, -111.3110 34.4197, -111.3110 35.3197, -112.2110 35.3197, -112.2110 34.4197))'),
+        ST_GeogFromWKB(z.z_boundary)
+    )
+  AND ST_Within(ST_GeogFromWKB(t.t_pickuploc), ST_GeogFromWKB(z.z_boundary))
+GROUP BY z.z_zonekey, z.z_name
+ORDER BY total_pickups DESC, z.z_zonekey ASC
+""").show(3)
+
+```
+
+## Q7：检测潜在的绕路行程
+
+**实际场景：** 标记报告距离远超上下车点直线距离的行程，作为绕路或虚增车费的信号。
+
+这是 geography 类型帮助最大的一条查询。geometry 版本以度为单位测量平面线段长度，再除以
+`0.000009` 假装它是米；geography 版本直接测量大地线，因此 `line_distance_m` 与
+`detour_ratio` 在整个数据集范围内都有意义，而不仅仅在赤道附近成立。
+
+**所考察的空间查询特性：**
+
+1. 由两点构造线（`ST_MakeLine`）
+2. 大地线长度（`ST_Length`，米）
+3. 带除零保护的比值计算
+
+
+```python
+sd.sql("""
+WITH trip_lengths AS (
+    SELECT
+        t.t_tripkey,
+        t.t_distance AS reported_distance_m,
+        ST_Length(
+            ST_MakeLine(
+                ST_GeogFromWKB(t.t_pickuploc),
+                ST_GeogFromWKB(t.t_dropoffloc)
+            )
+        ) AS line_distance_m -- metres, no degree conversion needed
+    FROM trip t
+)
+SELECT
+    t.t_tripkey,
+    t.reported_distance_m,
+    t.line_distance_m,
+    t.reported_distance_m / NULLIF(t.line_distance_m, 0) AS detour_ratio
+FROM trip_lengths t
+ORDER BY detour_ratio DESC NULLS LAST, reported_distance_m DESC, t_tripkey ASC
+LIMIT 100 -- Return only the top 100 highest-detour trips (bounded result set)
+""").show(3)
+
+```
+
+## Q8：统计每栋建筑 500 米范围内的上车次数
+
+**实际场景：** 找出产生最多上车活动的建筑物。
+
+500 米半径是自建筑轮廓起算的真实大地线距离，因此挪威的一栋建筑与肯尼亚的一栋建筑拥有相同
+物理尺度的覆盖范围——这与 geometry 套件不同，在那里 `0.0045°` 在高纬度会形成窄得多的条带。
+
+**所考察的空间查询特性：**
+
+1. 点与多边形之间基于大地线距离的空间连接（`ST_DWithin`，米）
+2. 在空间连接结果上进行聚合
+
+
+```python
+sd.sql("""
+SELECT b.b_buildingkey, b.b_name, COUNT(*) AS nearby_pickup_count
+FROM trip t
+JOIN building b
+ON ST_DWithin(ST_GeogFromWKB(t.t_pickuploc), ST_GeogFromWKB(b.b_boundary), 500) -- 500 m geodesic
+GROUP BY b.b_buildingkey, b.b_name
+ORDER BY nearby_pickup_count DESC, b.b_buildingkey ASC
+LIMIT 100 -- Return only the top 100 busiest buildings (bounded result set)
+""").show(3)
+
+```
+
+## Q9：建筑物融合（通过 IoU 检测重复/重叠）
+
+**实际场景：** 检测重复或重叠的建筑轮廓，以发现数据质量问题。
+
+这里 `area1`、`area2` 与 `overlap_area` 的单位是平方米而非平方度，因此可以直接解读。`iou`
+是面积之比，在两套查询中都是无量纲的——不过取值仍会不同，因为球面面积之比并不等于平面面积
+之比。
+
+**所考察的空间查询特性：**
+
+1. 带空间谓词的多边形-多边形自连接（`ST_Intersects`）
+2. 球面叠加运算（`ST_Intersection`）
+3. 球面面积（`ST_Area`，平方米）
+
+
+```python
+sd.sql("""
+WITH b1 AS (
+    SELECT b_buildingkey AS id, ST_GeogFromWKB(b_boundary) AS geog FROM building
+),
+b2 AS (
+    SELECT b_buildingkey AS id, ST_GeogFromWKB(b_boundary) AS geog FROM building
+),
+pairs AS (
+    SELECT
+        b1.id AS building_1,
+        b2.id AS building_2,
+        ST_Area(b1.geog) AS area1,        -- m^2
+        ST_Area(b2.geog) AS area2,        -- m^2
+        ST_Area(ST_Intersection(b1.geog, b2.geog)) AS overlap_area -- m^2
+    FROM b1
+    JOIN b2 ON b1.id < b2.id AND ST_Intersects(b1.geog, b2.geog)
+)
+SELECT
+    building_1,
+    building_2,
+    area1,
+    area2,
+    overlap_area,
+    CASE
+        WHEN overlap_area = 0 THEN 0.0
+        WHEN (area1 + area2 - overlap_area) = 0 THEN 1.0
+        ELSE overlap_area / (area1 + area2 - overlap_area)
+    END AS iou
+FROM pairs
+ORDER BY iou DESC, building_1 ASC, building_2 ASC
+LIMIT 100 -- Return only the top 100 most-overlapping building pairs (bounded result set)
+""").show(3)
+
+```
+
+## Q10：各区域内出发行程的统计
+
+**实际场景：** 按平均行程时长对区域排序，同时保留没有行程的区域。
+
+**所考察的空间查询特性：**
+
+1. 球面上的左空间连接（`ST_Within`），保留未匹配的区域
+2. 排序中带 `NULL` 处理的聚合
+
+
+```python
+sd.sql("""
+SELECT
+    z.z_zonekey,
+    z.z_name AS pickup_zone,
+    AVG(t.t_dropofftime - t.t_pickuptime) AS avg_duration,
+    AVG(t.t_distance) AS avg_distance,
+    COUNT(t.t_tripkey) AS num_trips
+FROM zone z
+LEFT JOIN trip t ON ST_Within(ST_GeogFromWKB(t.t_pickuploc), ST_GeogFromWKB(z.z_boundary))
+GROUP BY z.z_zonekey, z.z_name
+ORDER BY avg_duration DESC NULLS LAST, z.z_zonekey ASC
+LIMIT 100 -- Return only the top 100 zones by average trip duration (bounded result set)
+""").show(3)
+
+```
+
+## Q11：统计跨区域的行程数
+
+**实际场景：** 量化区域间的出行需求，用于公共交通规划。
+
+**所考察的空间查询特性：**
+
+1. 球面上两次独立的点在多边形内空间连接
+2. 在连接结果上的非空间过滤
+
+
+```python
+sd.sql("""
+SELECT COUNT(*) AS cross_zone_trip_count
+FROM trip t
+JOIN zone pickup_zone ON ST_Within(ST_GeogFromWKB(t.t_pickuploc), ST_GeogFromWKB(pickup_zone.z_boundary))
+JOIN zone dropoff_zone ON ST_Within(ST_GeogFromWKB(t.t_dropoffloc), ST_GeogFromWKB(dropoff_zone.z_boundary))
+WHERE pickup_zone.z_zonekey != dropoff_zone.z_zonekey
+""").show(3)
+
+```
+
+## Q12：按到最近 5 栋建筑的平均距离对上车点排序
+
+**实际场景：** 找出最孤立的上车点——距离周边任何建筑都最远的位置——用于覆盖度与服务空白分析。
+
+`avg_distance_to_5_nearest` 以米为单位，且近邻排序本身依据大地线距离而非平面度数，因此
+“最近的 5 栋建筑”是地面上真正最近的 5 栋。
+
+**所考察的空间查询特性：**
+
+1. 球面上的 K 最近邻空间连接（`ST_KNN`）
+2. 点到多边形的大地线距离（`ST_Distance`，米）
+3. 在 KNN 结果上进行聚合
+
+
+```sql
+WITH trip_with_geog AS (
+    SELECT t_tripkey, ST_GeogFromWKB(t_pickuploc) AS pickup_geog
+    FROM trip
+),
+building_with_geog AS (
+    SELECT ST_GeogFromWKB(b_boundary) AS boundary_geog
+    FROM building
+),
+knn AS (
+    SELECT
+        t.t_tripkey,
+        ST_Distance(t.pickup_geog, b.boundary_geog) AS distance_to_building -- metres
+    FROM trip_with_geog t
+    JOIN building_with_geog b ON ST_KNN(t.pickup_geog, b.boundary_geog, 5, TRUE) -- TRUE = rank by spherical distance
+)
+SELECT
+    t_tripkey,
+    AVG(distance_to_building) AS avg_distance_to_5_nearest
+FROM knn
+GROUP BY t_tripkey
+ORDER BY avg_distance_to_5_nearest DESC, t_tripkey ASC
+LIMIT 100 -- Return only the top 100 most-isolated pickups (bounded result set)
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,7 +32,8 @@ extra:
   spatialbench_links: &spatialbench_links
     - Framework:
         - Methodology: overview-methodology.md
-        - SpatialBench Queries: queries.md
+        - SpatialBench Queries (Geometry): queries.md
+        - SpatialBench Queries (Geography): geography-queries.md
         - Datasets & Generators: datasets-generators.md
         - Data Distributions: spatialbench-distributions.md
 
@@ -52,7 +53,8 @@ nav:
       - Home: index.md
       - Quickstart: quickstart.md
       - Methodology: overview-methodology.md
-      - Queries: queries.md
+      - SpatialBench Queries (Geometry): queries.md
+      - SpatialBench Queries (Geography): geography-queries.md
       - Datasets & Generators: datasets-generators.md
       - Data Distributions: spatialbench-distributions.md
       - Single Node Results: single-node-benchmarks.md
@@ -160,7 +162,8 @@ plugins:
               SpatialBench: SpatialBench
               Quickstart: 快速开始
               Methodology: 方法论
-              Queries: 查询
+              SpatialBench Queries (Geometry): SpatialBench 查询（几何）
+              SpatialBench Queries (Geography): SpatialBench 查询（地理）
               Datasets & Generators: 数据集与生成器
               Data Distributions: 数据分布
               Single Node Results: 单节点结果
@@ -170,7 +173,6 @@ plugins:
               Community: 社区
               Apache Software Foundation: Apache 软件基金会
               Framework: 框架
-              SpatialBench Queries: SpatialBench 查询
               Get Involved: 参与贡献
               Sedona OSS Blog: Sedona 开源博客
    - git-revision-date-localized:

--- a/notebooks/geography-queries.ipynb
+++ b/notebooks/geography-queries.ipynb
@@ -1,0 +1,706 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Run the SpatialBench Geography Queries\n"
+   ],
+   "id": "ea8c9061-69b2-458b-a0a0-7015f212243e"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "SpatialBench's [main query suite](https://sedona.apache.org/spatialbench/queries/) is a **geometry** benchmark: the WKB columns are\n",
+    "decoded with `ST_GeomFromWKB`, predicates use planar (2D Euclidean) edges, and every distance\n",
+    "threshold is an angle in degrees.\n",
+    "\n",
+    "This notebook defines the **geography** counterpart of the same 12 queries. The data is\n",
+    "unchanged — the same EPSG:4326 longitude/latitude WKB columns — but the columns are decoded\n",
+    "with `ST_GeogFromWKB`, so edges are interpreted as geodesics on a sphere and every measure\n",
+    "comes back in real-world units.\n",
+    "\n",
+    "## Why a second suite\n",
+    "\n",
+    "The geometry suite has to fake real-world units. It filters trips \"within 50 km\" of Sedona\n",
+    "using `ST_DWithin(..., 0.45)`, converts metres to degrees with `1 m = 0.000009 degree`, and\n",
+    "reports building overlap areas in square degrees.\n",
+    "\n",
+    "A degree of latitude is roughly 111 km everywhere, but a degree of longitude shrinks with the\n",
+    "cosine of the latitude. So `0.45` degrees is about 50 km tall and only about 41 km wide at\n",
+    "Sedona (34.87°N), and about 25 km wide at 60°N. Since SpatialBench data is generated across\n",
+    "eight continent-sized boxes spanning latitudes −56° to 78°, a degree-based radius is a\n",
+    "different real-world shape in every part of the dataset.\n",
+    "\n",
+    "The geography suite replaces all of that with metres and square metres:\n",
+    "\n",
+    "| | Geometry suite | Geography suite |\n",
+    "|---|---|---|\n",
+    "| Point/polygon constructor | `ST_GeomFromWKB`, `ST_GeomFromText` | `ST_GeogFromWKB`, `ST_GeogFromWKT` |\n",
+    "| Edge interpretation | straight lines in a plane | geodesics on a sphere |\n",
+    "| `ST_DWithin` threshold | degrees (`0.45`, `0.045`, `0.0045`) | metres (`50000`, `5000`, `500`) |\n",
+    "| `ST_Distance`, `ST_Length` | degrees | metres |\n",
+    "| `ST_Area` | square degrees | square metres |\n",
+    "| Unit conversion in SQL | `/ 0.000009` | none needed |\n",
+    "\n",
+    "!!! note \"The two suites are not row-for-row comparable\"\n",
+    "\n",
+    "    A 0.45° planar radius and a 50 000 m geodesic radius select different trips, so Q1\n",
+    "    returns a different 100 rows in each suite. That is the point of the exercise, not a\n",
+    "    discrepancy: each suite has its own ground truth, and results should only ever be\n",
+    "    compared within a suite.\n",
+    "\n",
+    "## The query module\n",
+    "\n",
+    "The same SQL is available outside this notebook from the query module, which prints the suite\n",
+    "for a given dialect:\n",
+    "\n",
+    "```bash\n",
+    "python3 spatialbench-queries/print_geography_queries.py SedonaDB\n",
+    "```\n",
+    "\n",
+    "Running the queries needs an engine with a `GEOGRAPHY` type whose measures are geodesic;\n",
+    "support for the individual functions is still filling in across engines, so check your\n",
+    "engine's own reference for what it implements. Q12 is defined below but is not carried in the\n",
+    "module and is not executed here: it is a K-nearest-neighbour join, and `ST_KNN` has no\n",
+    "geography form yet.\n"
+   ],
+   "id": "045da4c4-4138-4cea-922d-c8aa736bd3be"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Before you start\n"
+   ],
+   "id": "7b83571f-adce-4af5-a32a-0e65c6981fd3"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "%pip install -r ~/sedona-spatialbench/docs/requirements.txt\n"
+   ],
+   "execution_count": null,
+   "outputs": [],
+   "id": "b82dec9c-0cdc-4b93-8829-fad56c948dab"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Additionally, install the SpatialBench CLI and generate the synthetic data on your machine:\n",
+    "\n",
+    "```\n",
+    "# SpatialBench CLI\n",
+    "cargo install --path ./spatialbench-cli\n",
+    "# Generate the benchmarking data to the sf1-parquet directory\n",
+    "spatialbench-cli -s 1 --format=parquet --output-dir sf1-parquet\n",
+    "```\n",
+    "\n",
+    "Alternatively, download pre-generated data from [Hugging Face](https://huggingface.co/datasets/apache-sedona/spatialbench) instead of generating it (tables are published under `v<version>/sf<scale>/`; scale factors `sf0.1`, `sf1`, `sf10`, `sf100`):\n",
+    "\n",
+    "```\n",
+    "pip install huggingface-hub\n",
+    "hf download apache-sedona/spatialbench --repo-type dataset --include \"v0.1.0/sf1/**\" --local-dir spatialbench-data\n",
+    "```\n",
+    "\n",
+    "If you use the Hugging Face download, set `DATA_DIR = \"spatialbench-data/v0.1.0/sf1\"` in the data-loading cell below.\n"
+   ],
+   "id": "da533bee-cdc8-4986-8e70-020e3090e58f"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import sedona.db\n"
+   ],
+   "execution_count": null,
+   "outputs": [],
+   "id": "9129bbd0-a4e5-4f1b-b1b6-5069bf9da24a"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "sd = sedona.db.connect()\n"
+   ],
+   "execution_count": null,
+   "outputs": [],
+   "id": "d6233d87-a2d2-4032-8993-6aa894bd074f"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import os\n",
+    "\n",
+    "# The CLI writes flat files to sf1-parquet/; the Hugging Face download puts\n",
+    "# partitioned tables under spatialbench-data/v0.1.0/sf1/. Point DATA_DIR at\n",
+    "# whichever you used -- both layouts load below.\n",
+    "DATA_DIR = \"../sf1-parquet\"\n",
+    "\n",
+    "for table in [\"building\", \"customer\", \"driver\", \"trip\", \"vehicle\", \"zone\"]:\n",
+    "    flat = f\"{DATA_DIR}/{table}.parquet\"\n",
+    "    source = flat if os.path.exists(flat) else f\"{DATA_DIR}/{table}/*.parquet\"\n",
+    "    sd.read_parquet(source).to_view(table)\n"
+   ],
+   "execution_count": null,
+   "outputs": [],
+   "id": "ec2befdb-8fb7-4935-b5b6-b709c8537cff"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Q1: Find trips starting within 50km of Sedona city center, ordered by distance\n",
+    "\n",
+    "**Real-life scenario:** Identify and rank trips by proximity to a city center for urban\n",
+    "planning and transportation analysis.\n",
+    "\n",
+    "Unlike the geometry version, the 50 km radius is a true geodesic radius rather than a 0.45°\n",
+    "angular one, and `distance_to_center` is in metres.\n",
+    "\n",
+    "**Spatial query characteristics tested:**\n",
+    "\n",
+    "1. Geodesic distance-based spatial filtering (`ST_DWithin`, metres)\n",
+    "2. Geodesic distance calculation to a fixed point\n",
+    "3. Coordinate extraction (`ST_X`, `ST_Y`)\n",
+    "4. Ordering by spatial distance\n"
+   ],
+   "id": "c2b01c82-5d9a-4124-86d5-c408fadafdcc"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "sd.sql(\"\"\"\n",
+    "SELECT\n",
+    "    t.t_tripkey,\n",
+    "    -- A point's coordinates are identical under either edge interpretation, so the lon/lat\n",
+    "    -- projection stays on the geometry accessor, which is the more widely available one.\n",
+    "    ST_X(ST_GeomFromWKB(t.t_pickuploc)) AS pickup_lon,\n",
+    "    ST_Y(ST_GeomFromWKB(t.t_pickuploc)) AS pickup_lat,\n",
+    "    t.t_pickuptime,\n",
+    "    ST_Distance(\n",
+    "        ST_GeogFromWKB(t.t_pickuploc),\n",
+    "        ST_GeogFromWKT('POINT (-111.7610 34.8697)')\n",
+    "    ) AS distance_to_center -- metres\n",
+    "FROM trip t\n",
+    "WHERE ST_DWithin(\n",
+    "    ST_GeogFromWKB(t.t_pickuploc),\n",
+    "    ST_GeogFromWKT('POINT (-111.7610 34.8697)'),\n",
+    "    50000 -- 50 km geodesic radius around Sedona center\n",
+    ")\n",
+    "ORDER BY distance_to_center ASC, t.t_tripkey ASC\n",
+    "LIMIT 100 -- Return only the 100 closest trips (bounded result set)\n",
+    "\"\"\").show(3)\n"
+   ],
+   "execution_count": null,
+   "outputs": [],
+   "id": "864c4a4c-5f92-4199-af83-35ceb8ca0587"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Q2: Count trips starting within Coconino County\n",
+    "\n",
+    "**Real-life scenario:** Count trip activity inside an administrative boundary.\n",
+    "\n",
+    "The county polygon comes from Overture data with planar edges; reading it as a geography\n",
+    "reinterprets those edges as geodesics, which can move the boundary by a few metres relative\n",
+    "to the geometry suite and change the count for pickups that fall essentially on the border.\n",
+    "\n",
+    "**Spatial query characteristics tested:**\n",
+    "\n",
+    "1. Point-in-polygon spatial predicate on the sphere (`ST_Intersects`)\n",
+    "2. Scalar subquery producing the query geography\n"
+   ],
+   "id": "3d1a2580-0b1a-428d-bebe-5090e8fcd131"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "sd.sql(\"\"\"\n",
+    "SELECT COUNT(*) AS trip_count_in_coconino_county\n",
+    "FROM trip t\n",
+    "WHERE ST_Intersects(\n",
+    "    ST_GeogFromWKB(t.t_pickuploc),\n",
+    "    (SELECT ST_GeogFromWKB(z.z_boundary) FROM zone z WHERE z.z_name = 'Coconino County' LIMIT 1)\n",
+    ")\n",
+    "\"\"\").show(3)\n"
+   ],
+   "execution_count": null,
+   "outputs": [],
+   "id": "5b4930de-7dc7-4769-82ae-fed6a6720b9c"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Q3: Monthly trip statistics for a buffered box around Sedona city center\n",
+    "\n",
+    "**Real-life scenario:** Track monthly demand, revenue and trip duration in a metro area.\n",
+    "\n",
+    "The polygon literal is the same ring as in the geometry suite, but its edges are geodesics\n",
+    "here, so it is a spherical quadrilateral rather than a planar box.\n",
+    "\n",
+    "The ring is centred on Sedona and spans roughly **26.5 km east–west by 30 km north–south** —\n",
+    "about 13 km and 15 km from the centre along each axis, with the corners ~20 km out. The 5 000 m\n",
+    "buffer extends that to about 25 km at the corners.\n",
+    "\n",
+    "**Spatial query characteristics tested:**\n",
+    "\n",
+    "1. Geodesic buffered-polygon filtering (`ST_DWithin`, metres)\n",
+    "2. Temporal grouping with `DATE_TRUNC`\n",
+    "3. Multiple aggregations over a spatial filter\n"
+   ],
+   "id": "da569a61-1a84-446c-ab40-514dd1ba3ae4"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "sd.sql(\"\"\"\n",
+    "SELECT\n",
+    "    DATE_TRUNC('month', t.t_pickuptime) AS pickup_month,\n",
+    "    COUNT(t.t_tripkey) AS total_trips,\n",
+    "    AVG(t.t_distance) AS avg_distance,\n",
+    "    AVG(t.t_dropofftime - t.t_pickuptime) AS avg_duration,\n",
+    "    AVG(t.t_fare) AS avg_fare\n",
+    "FROM trip t\n",
+    "WHERE ST_DWithin(\n",
+    "    ST_GeogFromWKB(t.t_pickuploc),\n",
+    "    -- ~26.5 km E-W by ~30 km N-S about the center; corners sit ~20 km out\n",
+    "    ST_GeogFromWKT('POLYGON((-111.9060 34.7347, -111.6160 34.7347, -111.6160 35.0047, -111.9060 35.0047, -111.9060 34.7347))'),\n",
+    "    5000 -- Additional 5 km geodesic buffer, so ~25 km at the corners\n",
+    ")\n",
+    "GROUP BY pickup_month\n",
+    "ORDER BY pickup_month\n",
+    "\"\"\").show(3)\n"
+   ],
+   "execution_count": null,
+   "outputs": [],
+   "id": "1c989e1e-2620-4045-a5b3-00d86f886804"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Q4: Zone distribution of top 1000 trips by tip amount\n",
+    "\n",
+    "**Real-life scenario:** Find which neighbourhoods generate the most generous tips.\n",
+    "\n",
+    "**Spatial query characteristics tested:**\n",
+    "\n",
+    "1. Point-in-polygon spatial join on the sphere (`ST_Within`)\n",
+    "2. Spatial join against a `LIMIT`-bounded subquery\n",
+    "3. Aggregation on the spatial join result\n"
+   ],
+   "id": "db499419-2590-4457-90b6-7ce71d66dd05"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "sd.sql(\"\"\"\n",
+    "SELECT z.z_zonekey, z.z_name, COUNT(*) AS trip_count\n",
+    "FROM zone z\n",
+    "JOIN (\n",
+    "    SELECT t.t_pickuploc\n",
+    "    FROM trip t\n",
+    "    ORDER BY t.t_tip DESC, t.t_tripkey ASC\n",
+    "    LIMIT 1000 -- Replace 1000 with x (how many top tips you want)\n",
+    ") top_trips\n",
+    "ON ST_Within(ST_GeogFromWKB(top_trips.t_pickuploc), ST_GeogFromWKB(z.z_boundary))\n",
+    "GROUP BY z.z_zonekey, z.z_name\n",
+    "ORDER BY trip_count DESC, z.z_zonekey ASC\n",
+    "\"\"\").show(3)\n"
+   ],
+   "execution_count": null,
+   "outputs": [],
+   "id": "ff5e6806-a95c-421b-a643-e2b3e125a371"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Q5: Monthly travel patterns for repeat customers\n",
+    "\n",
+    "**Real-life scenario:** Measure how large an area each frequent customer travels across in a\n",
+    "month, from the convex hull of their dropoff locations.\n",
+    "\n",
+    "In the geography suite `monthly_travel_hull_area` is a spherical area in square metres, and\n",
+    "the hull itself is computed with geodesic edges.\n",
+    "\n",
+    "**Spatial query characteristics tested:**\n",
+    "\n",
+    "1. Geography aggregation into a collection (`ST_Collect_Agg`)\n",
+    "2. Spherical convex hull (`ST_ConvexHull`)\n",
+    "3. Spherical area (`ST_Area`, m²)\n",
+    "4. Grouped aggregation with `HAVING`\n"
+   ],
+   "id": "c5195afa-fdec-44e4-bdd2-fc0119bb30df"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "sd.sql(\"\"\"\n",
+    "SELECT\n",
+    "    c.c_custkey,\n",
+    "    c.c_name AS customer_name,\n",
+    "    DATE_TRUNC('month', t.t_pickuptime) AS pickup_month,\n",
+    "    ST_Area(ST_ConvexHull(ST_Collect_Agg(ST_GeogFromWKB(t.t_dropoffloc)))) AS monthly_travel_hull_area, -- m^2\n",
+    "    COUNT(*) AS dropoff_count\n",
+    "FROM trip t\n",
+    "JOIN customer c ON t.t_custkey = c.c_custkey\n",
+    "GROUP BY c.c_custkey, c.c_name, pickup_month\n",
+    "HAVING dropoff_count > 5 -- Only include repeat customers for meaningful hulls\n",
+    "ORDER BY monthly_travel_hull_area DESC, c.c_custkey ASC, pickup_month ASC\n",
+    "LIMIT 100 -- Return only the top 100 repeat customer-months by travel-hull area (bounded result set)\n",
+    "\"\"\").show(3)\n"
+   ],
+   "execution_count": null,
+   "outputs": [],
+   "id": "1cdc98ea-901d-4ebf-900d-331503dccbed"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Q6: Zone statistics for trips intersecting a bounding box\n",
+    "\n",
+    "**Real-life scenario:** Summarise trip activity for every zone touching a region of interest.\n",
+    "\n",
+    "**Spatial query characteristics tested:**\n",
+    "\n",
+    "1. Two spatial predicates in one join (`ST_Intersects` and `ST_Within`)\n",
+    "2. Polygon-polygon intersection test on the sphere\n",
+    "3. Aggregation over a doubly-filtered join\n"
+   ],
+   "id": "1a3662d0-7773-438f-8a8c-0a864ecd5a7f"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "sd.sql(\"\"\"\n",
+    "SELECT\n",
+    "    z.z_zonekey, z.z_name,\n",
+    "    COUNT(t.t_tripkey) AS total_pickups,\n",
+    "    AVG(t.t_distance) AS avg_distance,\n",
+    "    AVG(t.t_dropofftime - t.t_pickuptime) AS avg_duration\n",
+    "FROM trip t, zone z\n",
+    "WHERE ST_Intersects(\n",
+    "        ST_GeogFromWKT('POLYGON((-112.2110 34.4197, -111.3110 34.4197, -111.3110 35.3197, -112.2110 35.3197, -112.2110 34.4197))'),\n",
+    "        ST_GeogFromWKB(z.z_boundary)\n",
+    "    )\n",
+    "  AND ST_Within(ST_GeogFromWKB(t.t_pickuploc), ST_GeogFromWKB(z.z_boundary))\n",
+    "GROUP BY z.z_zonekey, z.z_name\n",
+    "ORDER BY total_pickups DESC, z.z_zonekey ASC\n",
+    "\"\"\").show(3)\n"
+   ],
+   "execution_count": null,
+   "outputs": [],
+   "id": "e83d492e-0f72-4905-80e2-41ace25dc4ce"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Q7: Detect potential route detours\n",
+    "\n",
+    "**Real-life scenario:** Flag trips whose reported distance greatly exceeds the straight-line\n",
+    "distance between pickup and dropoff, a signal for detours or fare padding.\n",
+    "\n",
+    "This is the query the geography type helps most. The geometry version measures a planar line\n",
+    "length in degrees and divides by `0.000009` to pretend it is metres; the geography version\n",
+    "measures the geodesic directly, so `line_distance_m` and `detour_ratio` are meaningful\n",
+    "everywhere in the dataset rather than only near the equator.\n",
+    "\n",
+    "**Spatial query characteristics tested:**\n",
+    "\n",
+    "1. Line construction from two points (`ST_MakeLine`)\n",
+    "2. Geodesic length (`ST_Length`, metres)\n",
+    "3. Ratio computation with division-by-zero guarding\n"
+   ],
+   "id": "e158202f-2d8c-4d95-a450-0add22b11b02"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "sd.sql(\"\"\"\n",
+    "WITH trip_lengths AS (\n",
+    "    SELECT\n",
+    "        t.t_tripkey,\n",
+    "        t.t_distance AS reported_distance_m,\n",
+    "        ST_Length(\n",
+    "            ST_MakeLine(\n",
+    "                ST_GeogFromWKB(t.t_pickuploc),\n",
+    "                ST_GeogFromWKB(t.t_dropoffloc)\n",
+    "            )\n",
+    "        ) AS line_distance_m -- metres, no degree conversion needed\n",
+    "    FROM trip t\n",
+    ")\n",
+    "SELECT\n",
+    "    t.t_tripkey,\n",
+    "    t.reported_distance_m,\n",
+    "    t.line_distance_m,\n",
+    "    t.reported_distance_m / NULLIF(t.line_distance_m, 0) AS detour_ratio\n",
+    "FROM trip_lengths t\n",
+    "ORDER BY detour_ratio DESC NULLS LAST, reported_distance_m DESC, t_tripkey ASC\n",
+    "LIMIT 100 -- Return only the top 100 highest-detour trips (bounded result set)\n",
+    "\"\"\").show(3)\n"
+   ],
+   "execution_count": null,
+   "outputs": [],
+   "id": "93a055b3-b374-49b7-b5c6-751d599e6289"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Q8: Count nearby pickups for each building within a 500m radius\n",
+    "\n",
+    "**Real-life scenario:** Find the buildings that generate the most pickup activity.\n",
+    "\n",
+    "The 500 m radius is a true geodesic distance from the building footprint, so the catchment is\n",
+    "the same physical size for a building in Norway as for one in Kenya — unlike the geometry\n",
+    "suite, where `0.0045°` is a much narrower band at high latitude.\n",
+    "\n",
+    "**Spatial query characteristics tested:**\n",
+    "\n",
+    "1. Geodesic distance spatial join between points and polygons (`ST_DWithin`, metres)\n",
+    "2. Aggregation on spatial join result\n"
+   ],
+   "id": "ffb2d12a-bd3f-4f24-b992-510a297fb21d"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "sd.sql(\"\"\"\n",
+    "SELECT b.b_buildingkey, b.b_name, COUNT(*) AS nearby_pickup_count\n",
+    "FROM trip t\n",
+    "JOIN building b\n",
+    "ON ST_DWithin(ST_GeogFromWKB(t.t_pickuploc), ST_GeogFromWKB(b.b_boundary), 500) -- 500 m geodesic\n",
+    "GROUP BY b.b_buildingkey, b.b_name\n",
+    "ORDER BY nearby_pickup_count DESC, b.b_buildingkey ASC\n",
+    "LIMIT 100 -- Return only the top 100 busiest buildings (bounded result set)\n",
+    "\"\"\").show(3)\n"
+   ],
+   "execution_count": null,
+   "outputs": [],
+   "id": "396d51d1-3a57-4490-a22e-5ab5a35e3579"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Q9: Building Conflation (duplicate/overlap detection via IoU)\n",
+    "\n",
+    "**Real-life scenario:** Detect duplicate or overlapping building footprints to find data\n",
+    "quality issues.\n",
+    "\n",
+    "`area1`, `area2` and `overlap_area` are square metres here rather than square degrees, which\n",
+    "makes them directly interpretable. `iou` is a ratio of areas, so it is dimensionless in both\n",
+    "suites — though the values still differ, because the ratio of spherical areas is not the ratio\n",
+    "of planar ones.\n",
+    "\n",
+    "**Spatial query characteristics tested:**\n",
+    "\n",
+    "1. Polygon-polygon self-join with a spatial predicate (`ST_Intersects`)\n",
+    "2. Spherical overlay (`ST_Intersection`)\n",
+    "3. Spherical area (`ST_Area`, m²)\n"
+   ],
+   "id": "94a12345-bc52-4990-9732-279dcfc1fdd9"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "sd.sql(\"\"\"\n",
+    "WITH b1 AS (\n",
+    "    SELECT b_buildingkey AS id, ST_GeogFromWKB(b_boundary) AS geog FROM building\n",
+    "),\n",
+    "b2 AS (\n",
+    "    SELECT b_buildingkey AS id, ST_GeogFromWKB(b_boundary) AS geog FROM building\n",
+    "),\n",
+    "pairs AS (\n",
+    "    SELECT\n",
+    "        b1.id AS building_1,\n",
+    "        b2.id AS building_2,\n",
+    "        ST_Area(b1.geog) AS area1,        -- m^2\n",
+    "        ST_Area(b2.geog) AS area2,        -- m^2\n",
+    "        ST_Area(ST_Intersection(b1.geog, b2.geog)) AS overlap_area -- m^2\n",
+    "    FROM b1\n",
+    "    JOIN b2 ON b1.id < b2.id AND ST_Intersects(b1.geog, b2.geog)\n",
+    ")\n",
+    "SELECT\n",
+    "    building_1,\n",
+    "    building_2,\n",
+    "    area1,\n",
+    "    area2,\n",
+    "    overlap_area,\n",
+    "    CASE\n",
+    "        WHEN overlap_area = 0 THEN 0.0\n",
+    "        WHEN (area1 + area2 - overlap_area) = 0 THEN 1.0\n",
+    "        ELSE overlap_area / (area1 + area2 - overlap_area)\n",
+    "    END AS iou\n",
+    "FROM pairs\n",
+    "ORDER BY iou DESC, building_1 ASC, building_2 ASC\n",
+    "LIMIT 100 -- Return only the top 100 most-overlapping building pairs (bounded result set)\n",
+    "\"\"\").show(3)\n"
+   ],
+   "execution_count": null,
+   "outputs": [],
+   "id": "1196b0a7-9e6b-4dc3-aedc-36d5ea709ba5"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Q10: Zone statistics for trips starting within each zone\n",
+    "\n",
+    "**Real-life scenario:** Rank zones by average trip duration, keeping zones with no trips.\n",
+    "\n",
+    "**Spatial query characteristics tested:**\n",
+    "\n",
+    "1. Left spatial join on the sphere (`ST_Within`), preserving unmatched zones\n",
+    "2. Aggregation with `NULL` handling in the ordering\n"
+   ],
+   "id": "8e682b5d-e127-4f36-b61d-5eac206718d0"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "sd.sql(\"\"\"\n",
+    "SELECT\n",
+    "    z.z_zonekey,\n",
+    "    z.z_name AS pickup_zone,\n",
+    "    AVG(t.t_dropofftime - t.t_pickuptime) AS avg_duration,\n",
+    "    AVG(t.t_distance) AS avg_distance,\n",
+    "    COUNT(t.t_tripkey) AS num_trips\n",
+    "FROM zone z\n",
+    "LEFT JOIN trip t ON ST_Within(ST_GeogFromWKB(t.t_pickuploc), ST_GeogFromWKB(z.z_boundary))\n",
+    "GROUP BY z.z_zonekey, z.z_name\n",
+    "ORDER BY avg_duration DESC NULLS LAST, z.z_zonekey ASC\n",
+    "LIMIT 100 -- Return only the top 100 zones by average trip duration (bounded result set)\n",
+    "\"\"\").show(3)\n"
+   ],
+   "execution_count": null,
+   "outputs": [],
+   "id": "fafcf45a-eb6e-40df-bc02-0e9eff0146dd"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Q11: Count trips that cross between different zones\n",
+    "\n",
+    "**Real-life scenario:** Quantify inter-zone travel demand for transit planning.\n",
+    "\n",
+    "**Spatial query characteristics tested:**\n",
+    "\n",
+    "1. Two independent point-in-polygon spatial joins on the sphere\n",
+    "2. Non-spatial filter on the join result\n"
+   ],
+   "id": "7c971f88-2e17-40c7-94b4-0d60da628bd2"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "sd.sql(\"\"\"\n",
+    "SELECT COUNT(*) AS cross_zone_trip_count\n",
+    "FROM trip t\n",
+    "JOIN zone pickup_zone ON ST_Within(ST_GeogFromWKB(t.t_pickuploc), ST_GeogFromWKB(pickup_zone.z_boundary))\n",
+    "JOIN zone dropoff_zone ON ST_Within(ST_GeogFromWKB(t.t_dropoffloc), ST_GeogFromWKB(dropoff_zone.z_boundary))\n",
+    "WHERE pickup_zone.z_zonekey != dropoff_zone.z_zonekey\n",
+    "\"\"\").show(3)\n"
+   ],
+   "execution_count": null,
+   "outputs": [],
+   "id": "dad62399-cc5b-4116-ab60-757a01c9aa61"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Q12: Rank trip pickups by average distance to their 5 nearest buildings\n",
+    "\n",
+    "**Real-life scenario:** Find the most isolated pickups — those farthest from any surrounding\n",
+    "building — for coverage and service-gap analysis.\n",
+    "\n",
+    "`avg_distance_to_5_nearest` is in metres, and the neighbour ranking itself is by geodesic\n",
+    "distance rather than planar degrees, so the \"5 nearest buildings\" are genuinely the 5 nearest\n",
+    "on the ground.\n",
+    "\n",
+    "**Spatial query characteristics tested:**\n",
+    "\n",
+    "1. K-nearest-neighbour spatial join on the sphere (`ST_KNN`)\n",
+    "2. Geodesic point-to-polygon distance (`ST_Distance`, metres)\n",
+    "3. Aggregation over the KNN result\n"
+   ],
+   "id": "1757f6d8-8475-4178-b7aa-abfacd3b589a"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```sql\n",
+    "WITH trip_with_geog AS (\n",
+    "    SELECT t_tripkey, ST_GeogFromWKB(t_pickuploc) AS pickup_geog\n",
+    "    FROM trip\n",
+    "),\n",
+    "building_with_geog AS (\n",
+    "    SELECT ST_GeogFromWKB(b_boundary) AS boundary_geog\n",
+    "    FROM building\n",
+    "),\n",
+    "knn AS (\n",
+    "    SELECT\n",
+    "        t.t_tripkey,\n",
+    "        ST_Distance(t.pickup_geog, b.boundary_geog) AS distance_to_building -- metres\n",
+    "    FROM trip_with_geog t\n",
+    "    JOIN building_with_geog b ON ST_KNN(t.pickup_geog, b.boundary_geog, 5, TRUE) -- TRUE = rank by spherical distance\n",
+    ")\n",
+    "SELECT\n",
+    "    t_tripkey,\n",
+    "    AVG(distance_to_building) AS avg_distance_to_5_nearest\n",
+    "FROM knn\n",
+    "GROUP BY t_tripkey\n",
+    "ORDER BY avg_distance_to_5_nearest DESC, t_tripkey ASC\n",
+    "LIMIT 100 -- Return only the top 100 most-isolated pickups (bounded result set)\n",
+    "```\n"
+   ],
+   "id": "0a873e98-8363-4df9-b7ed-37c7329ebe7a"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/spatialbench-queries/print_geography_queries.py
+++ b/spatialbench-queries/print_geography_queries.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+import sys
+
+from print_queries import SpatialBenchBenchmark
+
+
+class GeographySpatialBenchBenchmark:
+    """The geography counterpart of the SpatialBench queries, in the Sedona/Spark SQL dialect.
+
+    The underlying data is unchanged: the same EPSG:4326 lon/lat WKB columns the geometry
+    suite reads. Only the edge interpretation changes -- geography edges are geodesics on a
+    sphere rather than straight lines in a Cartesian plane -- so every measure comes back in
+    real units. Distances and lengths are metres, areas are square metres, and the degree
+    conversion factors the geometry suite carries (0.45 "= 50 km", /0.000009 "= 1 m") are
+    gone. Those factors only hold near the equator along longitude, so the two suites select
+    different rows by construction; see docs/geography-queries.md.
+
+    Running these needs an engine with a GEOGRAPHY type whose measures are geodesic; support
+    for the individual functions is still filling in, so check the engine's own reference.
+
+    Q12 is documented in docs/geography-queries.md but deliberately absent here: it is a
+    K-nearest-neighbour join, and ST_KNN has no geography form yet. It is added once one lands.
+    """
+
+    # Reuse the geometry suite's query-collection reflection *without* inheriting its SQL:
+    # subclassing SpatialBenchBenchmark would silently reintroduce the geometry q12 into
+    # this suite.
+    queries = SpatialBenchBenchmark.queries
+
+    def dialect(self) -> str:
+        """Return the dialect of the benchmark."""
+        return "SedonaSpark (Geography)"
+
+    @staticmethod
+    def q1() -> str:
+        return """
+-- Q1 (Geography): Find trips starting within 50km of Sedona city center, ordered by geodesic distance
+SELECT
+   t.t_tripkey,
+   -- A point's coordinates are identical under either edge interpretation, so the lon/lat
+   -- projection stays on the geometry accessor, which is the more widely available one.
+   ST_X(ST_GeomFromWKB(t.t_pickuploc)) AS pickup_lon, ST_Y(ST_GeomFromWKB(t.t_pickuploc)) AS pickup_lat,
+   t.t_pickuptime,
+   ST_Distance(ST_GeogFromWKB(t.t_pickuploc), ST_GeogFromWKT('POINT (-111.7610 34.8697)')) AS distance_to_center -- metres
+FROM trip t
+WHERE ST_DWithin(ST_GeogFromWKB(t.t_pickuploc), ST_GeogFromWKT('POINT (-111.7610 34.8697)'), 50000) -- 50 km geodesic radius around Sedona center
+ORDER BY distance_to_center ASC, t.t_tripkey ASC
+LIMIT 100 -- Return only the 100 closest trips (bounded result set)
+               """
+
+    @staticmethod
+    def q2() -> str:
+        return """
+-- Q2 (Geography): Count trips starting within Coconino County (Arizona) zone
+SELECT COUNT(*) AS trip_count_in_coconino_county
+FROM trip t
+WHERE ST_Intersects(ST_GeogFromWKB(t.t_pickuploc), (SELECT ST_GeogFromWKB(z.z_boundary) FROM zone z WHERE z.z_name = 'Coconino County' LIMIT 1))
+               """
+
+    @staticmethod
+    def q3() -> str:
+        return """
+-- Q3 (Geography): Monthly trip statistics for a buffered box around Sedona city center
+SELECT
+   DATE_TRUNC('month', t.t_pickuptime) AS pickup_month, COUNT(t.t_tripkey) AS total_trips,
+   AVG(t.t_distance) AS avg_distance, AVG(t.t_dropofftime - t.t_pickuptime) AS avg_duration,
+   AVG(t.t_fare) AS avg_fare
+FROM trip t
+WHERE ST_DWithin(
+             ST_GeogFromWKB(t.t_pickuploc),
+             -- Same ring as the geometry suite, but its edges are geodesics here.
+             -- Spans ~26.5 km E-W by ~30 km N-S about the center; corners sit ~20 km out.
+             ST_GeogFromWKT('POLYGON((-111.9060 34.7347, -111.6160 34.7347, -111.6160 35.0047, -111.9060 35.0047, -111.9060 34.7347))'),
+             5000 -- Additional 5 km geodesic buffer, so ~25 km at the corners
+     )
+GROUP BY pickup_month
+ORDER BY pickup_month
+"""
+
+    @staticmethod
+    def q4() -> str:
+        return """
+-- Q4 (Geography): Zone distribution of top 1000 trips by tip amount
+SELECT z.z_zonekey, z.z_name, COUNT(*) AS trip_count
+FROM
+   zone z
+       JOIN (
+       SELECT t.t_pickuploc
+       FROM trip t
+       ORDER BY t.t_tip DESC, t.t_tripkey ASC
+           LIMIT 1000 -- Replace 1000 with x (how many top tips you want)
+   ) top_trips ON ST_Within(ST_GeogFromWKB(top_trips.t_pickuploc), ST_GeogFromWKB(z.z_boundary))
+GROUP BY z.z_zonekey, z.z_name
+ORDER BY trip_count DESC, z.z_zonekey ASC
+               """
+
+    @staticmethod
+    def q5() -> str:
+        return """
+-- Q5 (Geography): Monthly travel patterns for repeat customers (convex hull of dropoff locations)
+SELECT
+   c.c_custkey, c.c_name AS customer_name,
+   DATE_TRUNC('month', t.t_pickuptime) AS pickup_month,
+   ST_Area(ST_ConvexHull(ST_Collect(ARRAY_AGG(ST_GeogFromWKB(t.t_dropoffloc))))) AS monthly_travel_hull_area, -- m^2, spherical
+   COUNT(*) as dropoff_count
+FROM trip t JOIN customer c ON t.t_custkey = c.c_custkey
+GROUP BY c.c_custkey, c.c_name, pickup_month
+HAVING dropoff_count > 5 -- Only include repeat customers for meaningful hulls
+ORDER BY monthly_travel_hull_area DESC, c.c_custkey ASC, pickup_month ASC
+LIMIT 100 -- Return only the top 100 repeat customer-months by travel-hull area (bounded result set)
+            """
+
+    @staticmethod
+    def q6() -> str:
+        return """
+-- Q6 (Geography): Zone statistics for trips intersecting a bounding box
+SELECT
+   z.z_zonekey, z.z_name,
+   COUNT(t.t_tripkey) AS total_pickups, AVG(t.t_distance) AS avg_distance,
+   AVG(t.t_dropofftime - t.t_pickuptime) AS avg_duration
+FROM trip t, zone z
+WHERE ST_Intersects(ST_GeogFromWKT('POLYGON((-112.2110 34.4197, -111.3110 34.4197, -111.3110 35.3197, -112.2110 35.3197, -112.2110 34.4197))'), ST_GeogFromWKB(z.z_boundary))
+ AND ST_Within(ST_GeogFromWKB(t.t_pickuploc), ST_GeogFromWKB(z.z_boundary))
+GROUP BY z.z_zonekey, z.z_name
+ORDER BY total_pickups DESC, z.z_zonekey ASC
+               """
+
+    @staticmethod
+    def q7() -> str:
+        return """
+-- Q7 (Geography): Detect potential route detours by comparing reported vs. geodesic distances
+WITH trip_lengths AS (
+   SELECT
+       t.t_tripkey,
+       t.t_distance AS reported_distance_m,
+       ST_Length(
+               ST_MakeLine(
+                       ST_GeogFromWKB(t.t_pickuploc),
+                       ST_GeogFromWKB(t.t_dropoffloc)
+               )
+       ) AS line_distance_m -- metres; no degree conversion factor needed
+   FROM trip t
+)
+SELECT
+   t.t_tripkey,
+   t.reported_distance_m,
+   t.line_distance_m,
+   t.reported_distance_m / NULLIF(t.line_distance_m, 0) AS detour_ratio
+FROM trip_lengths t
+ORDER BY detour_ratio DESC NULLS LAST, reported_distance_m DESC, t_tripkey ASC
+LIMIT 100 -- Return only the top 100 highest-detour trips (bounded result set)
+               """
+
+    @staticmethod
+    def q8() -> str:
+        return """
+-- Q8 (Geography): Count nearby pickups for each building within 500m radius
+SELECT b.b_buildingkey, b.b_name, COUNT(*) AS nearby_pickup_count
+FROM trip t JOIN building b ON ST_DWithin(ST_GeogFromWKB(t.t_pickuploc), ST_GeogFromWKB(b.b_boundary), 500) -- 500 m geodesic
+GROUP BY b.b_buildingkey, b.b_name
+ORDER BY nearby_pickup_count DESC, b.b_buildingkey ASC
+LIMIT 100 -- Return only the top 100 busiest buildings (bounded result set)
+               """
+
+    @staticmethod
+    def q9() -> str:
+        return """
+-- Q9 (Geography): Building Conflation (duplicate/overlap detection via IoU), deterministic order
+-- Areas are square metres. Needs geography ST_Intersection: available in SedonaDB, not yet in Apache Sedona.
+WITH b1 AS (
+   SELECT b_buildingkey AS id, ST_GeogFromWKB(b_boundary) AS geog
+   FROM building
+),
+    b2 AS (
+        SELECT b_buildingkey AS id, ST_GeogFromWKB(b_boundary) AS geog
+        FROM building
+    ),
+    pairs AS (
+        SELECT
+            b1.id AS building_1,
+            b2.id AS building_2,
+            ST_Area(b1.geog) AS area1,
+            ST_Area(b2.geog) AS area2,
+            ST_Area(ST_Intersection(b1.geog, b2.geog)) AS overlap_area
+        FROM b1
+                 JOIN b2
+                      ON b1.id < b2.id
+                          AND ST_Intersects(b1.geog, b2.geog)
+    )
+SELECT
+   building_1,
+   building_2,
+   area1,
+   area2,
+   overlap_area,
+   -- A ratio of areas, so the unit change cancels: iou is dimensionless in both suites
+   CASE
+       WHEN overlap_area = 0 THEN 0.0
+       WHEN (area1 + area2 - overlap_area) = 0 THEN 1.0
+       ELSE overlap_area / (area1 + area2 - overlap_area)
+       END AS iou
+FROM pairs
+ORDER BY iou DESC, building_1 ASC, building_2 ASC
+LIMIT 100 -- Return only the top 100 most-overlapping building pairs (bounded result set)
+               """
+
+    @staticmethod
+    def q10() -> str:
+        return """
+-- Q10 (Geography): Zone statistics for trips starting within each zone
+SELECT
+   z.z_zonekey, z.z_name AS pickup_zone, AVG(t.t_dropofftime - t.t_pickuptime) AS avg_duration,
+   AVG(t.t_distance) AS avg_distance, COUNT(t.t_tripkey) AS num_trips
+FROM zone z LEFT JOIN trip t ON ST_Within(ST_GeogFromWKB(t.t_pickuploc), ST_GeogFromWKB(z.z_boundary))
+GROUP BY z.z_zonekey, z.z_name
+ORDER BY avg_duration DESC NULLS LAST, z.z_zonekey ASC
+LIMIT 100 -- Return only the top 100 zones by average trip duration (bounded result set)
+               """
+
+    @staticmethod
+    def q11() -> str:
+        return """
+-- Q11 (Geography): Count trips that cross between different zones
+SELECT COUNT(*) AS cross_zone_trip_count
+FROM
+   trip t
+       JOIN zone pickup_zone ON ST_Within(ST_GeogFromWKB(t.t_pickuploc), ST_GeogFromWKB(pickup_zone.z_boundary))
+       JOIN zone dropoff_zone ON ST_Within(ST_GeogFromWKB(t.t_dropoffloc), ST_GeogFromWKB(dropoff_zone.z_boundary))
+WHERE pickup_zone.z_zonekey != dropoff_zone.z_zonekey
+               """
+
+
+class SedonaDBGeographySpatialBenchBenchmark(GeographySpatialBenchBenchmark):
+    """A SedonaDB-specific implementation of the geography SpatialBench benchmark.
+
+    As in the geometry suite, only Q5 differs: SedonaDB spells the aggregate ST_Collect_Agg
+    rather than ST_Collect(ARRAY_AGG(...)).
+    """
+
+    def dialect(self) -> str:
+        """Return the dialect of the benchmark."""
+        return "SedonaDB (Geography)"
+
+    @staticmethod
+    def q5() -> str:
+        return """
+-- Q5 (SedonaDB, Geography): SedonaDB uses ST_Collect_Agg (with _Agg suffix) for aggregate functions.
+SELECT
+    c.c_custkey, c.c_name AS customer_name,
+    DATE_TRUNC('month', t.t_pickuptime) AS pickup_month,
+    ST_Area(ST_ConvexHull(ST_Collect_Agg(ST_GeogFromWKB(t.t_dropoffloc)))) AS monthly_travel_hull_area, -- m^2, spherical
+    COUNT(*) as dropoff_count
+FROM trip t JOIN customer c ON t.t_custkey = c.c_custkey
+GROUP BY c.c_custkey, c.c_name, pickup_month
+HAVING dropoff_count > 5 -- Only include repeat customers for meaningful hulls
+ORDER BY monthly_travel_hull_area DESC, c.c_custkey ASC, pickup_month ASC
+LIMIT 100 -- Return only the top 100 repeat customer-months by travel-hull area (bounded result set)
+               """
+
+
+def main():
+    query_classes = {
+        "SedonaSpark": GeographySpatialBenchBenchmark,
+        "SedonaDB": SedonaDBGeographySpatialBenchBenchmark,
+    }
+
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <dialect>")
+        print(f"Available dialects: {', '.join(query_classes.keys())}")
+        sys.exit(1)
+
+    dialect_arg = sys.argv[1]
+
+    if dialect_arg not in query_classes:
+        print(f"Unknown dialect: {dialect_arg}")
+        print(f"Available dialects: {', '.join(query_classes.keys())}")
+        sys.exit(1)
+
+    queries = query_classes[dialect_arg]().queries()
+
+    for query in queries.values():
+        print(query)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #125.

Every SpatialBench query today is **geometry**: WKB columns are decoded with `ST_GeomFromWKB`, predicates use planar edges, and every distance threshold is an angle in degrees with a hand-rolled conversion — `0.45` "= 50 km", `0.045` "= 5 km", `0.0045` "≈ 500 m", `/ 0.000009` "1 m = 0.000009 degree". Areas in Q5 and Q9 come out in square degrees.

Those factors only hold near the equator along longitude. `0.45°` is ~50 km tall but ~41 km wide at Sedona (34.87°N) and ~25 km wide at 60°N, and the generator scatters data across eight continent boxes spanning latitudes −56° to 78° — so a degree-based radius is a different real-world shape in every part of the dataset.

Geography types interpret edges as geodesics and return metric units, so this adds the geography counterpart of the suite.

## What's here

- **`docs/geography-queries.md`** (+ `.zh.md` mirror, nav entries in `mkdocs.yml`) — defines the geography version of **all 12 queries**, each with its real-life scenario, the spatial characteristics it exercises, and its SQL. Structured to match `queries.md`.
- **`spatialbench-queries/print_geography_queries.py`** — carries 11 of them. Q12 is defined in the docs but not the module: it is a KNN join and `ST_KNN` has no geography form yet.

What changes across the suite: `ST_GeomFromWKB` → `ST_GeogFromWKB`, `ST_GeomFromText` → `ST_GeogFromWKT`, degree thresholds → metres (`50000`, `5000`, `500`), areas → square metres, and Q7 drops the `/ 0.000009` conversion entirely. Output column names, `ORDER BY` clauses, `LIMIT`s and tiebreakers are unchanged from the geometry suite.

Nothing else is touched — `print_queries.py`, the benchmark harness, the CI matrix and the committed answers all stay as they are. Two follow-ups are filed: #133 to commit the notebook's executed outputs, and #134 to run the suite in the benchmark and commit geography ground-truth answers. The two suites need **separate** answer sets: a 0.45° planar radius and a 50 000 m geodesic radius select different rows by construction, so their results are not row-for-row comparable. Wiring the suite into `run_benchmark.py` and generating geography ground truth is deliberately left for a follow-up.

The geography base class deliberately does **not** subclass `SpatialBenchBenchmark` — that would silently reintroduce the geometry Q12 into this suite — so it borrows only the `queries()` reflection helper. As in the geometry suite, Q5 is the one query needing a SedonaDB-specific spelling (`ST_Collect_Agg` vs `ST_Collect(ARRAY_AGG(...))`).

## Validation

The suite was executed at SF0.1 and SF1, not just generated and eyeballed:

| Query | Against the committed geometry answer |
|---|---|
| Q2 | **exact match** (541) |
| Q3 | row count matches (22) |
| Q4 | **identical** — 258 zones, same counts, same order |
| Q9 | self-join finds the same 37 building pairs |
| Q1, Q5, Q7, Q8 | 100 rows each; differ as expected — metres/m² vs degrees |

## How to check it

```bash
python3 spatialbench-queries/print_geography_queries.py SedonaDB
python3 spatialbench-queries/print_geography_queries.py SedonaSpark
mkdocs build --strict
```

Running the SQL needs an engine with a `GEOGRAPHY` type whose measures are geodesic; support for the individual functions is still filling in across engines.

