### PR TITLE
Upgrade to Arrow/Parquet 58 and DataFusion 54.1

### DIFF
--- a/spatialbench-arrow/Cargo.toml
+++ b/spatialbench-arrow/Cargo.toml
@@ -29,11 +29,11 @@ keywords = ["spatial", "geospatial", "data-generation", "apache-arrow"]
 categories = ["science::geo", "database", "data-structures"]
 
 [dependencies]
-arrow = { version = "56", default-features = false, features = ["prettyprint"] }
+arrow = { version = "58", default-features = false, features = ["prettyprint"] }
 spatialbench = { path = "../spatialbench", version = "0.3.0" }
 geo = { workspace = true }
 geozero = { workspace = true }
 
 [dev-dependencies]
-arrow-csv = "56"
+arrow-csv = "58"
 chrono = "0.4.39"

--- a/spatialbench-cli/Cargo.toml
+++ b/spatialbench-cli/Cargo.toml
@@ -29,8 +29,8 @@ keywords = ["spatial", "geospatial", "benchmark", "cli", "data-generation"]
 categories = ["science::geo", "database", "command-line-utilities", "development-tools"]
 
 [dependencies]
-arrow = "56"
-parquet = "56"
+arrow = "58"
+parquet = "58"
 clap = { version = "4.5.32", features = ["derive"] }
 spatialbench = { path = "../spatialbench", version = "0.3.0"}
 spatialbench-arrow = { path = "../spatialbench-arrow", version = "0.3.0" }
@@ -42,10 +42,8 @@ env_logger = "0.11.7"
 serde = { version = "1.0.219", features = ["derive"] }
 anyhow = "1.0.99"
 serde_yaml = "0.9.33"
-datafusion = "50.2"
-object_store = { version = "0.12.4", features = ["http", "aws"] }
-arrow-array = "56"
-arrow-schema = "56"
+datafusion = "54.1"
+object_store = { version = "0.13.2", features = ["http", "aws"] }
 url = "2.5.7"
 bytes = "1.10.1"
 

--- a/spatialbench-cli/src/parquet.rs
+++ b/spatialbench-cli/src/parquet.rs
@@ -21,12 +21,11 @@ use crate::statistics::WriteStatistics;
 use arrow::datatypes::SchemaRef;
 use futures::StreamExt;
 use log::debug;
-use parquet::arrow::arrow_writer::{compute_leaves, get_column_writers, ArrowColumnChunk};
+use parquet::arrow::arrow_writer::{compute_leaves, ArrowColumnChunk, ArrowRowGroupWriterFactory};
 use parquet::arrow::ArrowSchemaConverter;
 use parquet::basic::Compression;
 use parquet::file::properties::WriterProperties;
 use parquet::file::writer::SerializedFileWriter;
-use parquet::schema::types::SchemaDescPtr;
 use spatialbench_arrow::RecordBatchIterator;
 use std::io;
 use std::io::Write;
@@ -85,15 +84,23 @@ where
             .unwrap(),
     );
 
+    let root_schema = parquet_schema.root_schema_ptr();
+    let writer = SerializedFileWriter::new(writer, root_schema, Arc::clone(&writer_properties))
+        .map_err(io::Error::from)?;
+    let row_group_factory = Arc::new(ArrowRowGroupWriterFactory::new(
+        &writer,
+        Arc::clone(&schema),
+    ));
+
     // create a stream that computes the data for each row group
     let mut row_group_stream = futures::stream::iter(iter_iter)
-        .map(async |iter| {
-            let parquet_schema = Arc::clone(&parquet_schema);
-            let writer_properties = Arc::clone(&writer_properties);
+        .enumerate()
+        .map(async |(row_group_index, iter)| {
+            let row_group_factory = Arc::clone(&row_group_factory);
             let schema = Arc::clone(&schema);
             // run on a separate thread
             tokio::task::spawn(async move {
-                encode_row_group(parquet_schema, writer_properties, schema, iter)
+                encode_row_group(row_group_factory, schema, row_group_index, iter)
             })
             .await
             .expect("Inner task panicked")
@@ -105,16 +112,12 @@ where
     // A blocking task that writes the row groups to the file
     // done in a blocking task to avoid having a thread waiting on IO
     // Now, read each completed row group and write it to the file
-    let root_schema = parquet_schema.root_schema_ptr();
-    let writer_properties_captured = Arc::clone(&writer_properties);
     let (tx, mut rx): (
         Sender<Vec<ArrowColumnChunk>>,
         Receiver<Vec<ArrowColumnChunk>>,
     ) = tokio::sync::mpsc::channel(num_threads);
     let writer_task = tokio::task::spawn_blocking(move || {
-        // Create parquet writer
-        let mut writer = SerializedFileWriter::new(writer, root_schema, writer_properties_captured)
-            .map_err(io::Error::from)?;
+        let mut writer = writer;
 
         while let Some(chunks) = rx.blocking_recv() {
             // Start row group
@@ -162,17 +165,21 @@ where
 /// potentially encode multiple columns with different threads .
 ///
 /// Returns an array of [`ArrowColumnChunk`]
+/// `schema` must be the same schema the `row_group_factory` was built from, as
+/// the leaf writers it creates are laid out according to that schema.
 fn encode_row_group<I>(
-    parquet_schema: SchemaDescPtr,
-    writer_properties: Arc<WriterProperties>,
+    row_group_factory: Arc<ArrowRowGroupWriterFactory>,
     schema: SchemaRef,
+    row_group_index: usize,
     iter: I,
 ) -> Vec<ArrowColumnChunk>
 where
     I: RecordBatchIterator,
 {
     // Create writers for each of the leaf columns
-    let mut col_writers = get_column_writers(&parquet_schema, &writer_properties, &schema).unwrap();
+    let mut col_writers = row_group_factory
+        .create_column_writers(row_group_index)
+        .unwrap();
 
     // generate the data and send it to the tasks (via the sender channels)
     for batch in iter {

--- a/spatialbench-cli/src/s3_writer.rs
+++ b/spatialbench-cli/src/s3_writer.rs
@@ -29,7 +29,7 @@ use bytes::Bytes;
 use log::{debug, info};
 use object_store::aws::AmazonS3Builder;
 use object_store::path::Path as ObjectPath;
-use object_store::ObjectStore;
+use object_store::{ObjectStore, ObjectStoreExt};
 use std::io::{self, Write};
 use std::sync::Arc;
 use tokio::sync::mpsc;

--- a/spatialbench-cli/src/zone/partition.rs
+++ b/spatialbench-cli/src/zone/partition.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::zone::stats::ZoneTableStats;
-use arrow_array::RecordBatch;
+use arrow::array::RecordBatch;
 use datafusion::prelude::*;
 use log::{debug, info};
 

--- a/spatialbench-cli/src/zone/transform.rs
+++ b/spatialbench-cli/src/zone/transform.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use anyhow::Result;
-use arrow_schema::Schema;
+use arrow::datatypes::Schema;
 use datafusion::{prelude::*, sql::TableReference};
 use log::{debug, info};
 

--- a/spatialbench-cli/src/zone/writer.rs
+++ b/spatialbench-cli/src/zone/writer.rs
@@ -17,8 +17,7 @@
 
 use crate::s3_writer::S3Writer;
 use anyhow::Result;
-use arrow_array::RecordBatch;
-use arrow_schema::SchemaRef;
+use arrow::{array::RecordBatch, datatypes::SchemaRef};
 use log::{debug, info};
 use parquet::{arrow::ArrowWriter, file::properties::WriterProperties};
 use std::{path::PathBuf, sync::Arc, time::Instant};
@@ -40,7 +39,7 @@ impl ParquetWriter {
 
         let props = WriterProperties::builder()
             .set_compression(args.parquet_compression)
-            .set_max_row_group_size(rows_per_group)
+            .set_max_row_group_row_count(Some(rows_per_group))
             .build();
 
         debug!("Using row group size: {} rows", rows_per_group);

--- a/spatialbench-cli/tests/cli_integration.rs
+++ b/spatialbench-cli/tests/cli_integration.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow_array::RecordBatch;
+use arrow::array::RecordBatch;
 use assert_cmd::Command;
 use parquet::arrow::arrow_reader::{ArrowReaderOptions, ParquetRecordBatchReaderBuilder};
 use parquet::file::metadata::ParquetMetaDataReader;

--- a/spatialbench-cli/tests/s3_integration.rs
+++ b/spatialbench-cli/tests/s3_integration.rs
@@ -31,7 +31,7 @@
 
 use assert_cmd::Command;
 use object_store::aws::AmazonS3Builder;
-use object_store::ObjectStore;
+use object_store::{ObjectStore, ObjectStoreExt};
 use std::sync::Arc;
 
 /// Build an S3 client pointing at the MinIO instance, using the same env


### PR DESCRIPTION
Hi Sedona maintainers, thanks in advance for taking a look at this one.

## What

Moves the workspace up to Arrow/Parquet 58, DataFusion 54.1, and object_store 0.13.2.

| Dependency | Before | After |
| --- | --- | --- |
| `arrow`, `parquet`, `arrow-csv` | 56 | 58 |
| `datafusion` | 50.2 | 54.1 |
| `object_store` | 0.12.4 | 0.13.2 |
| `arrow-array`, `arrow-schema` | 56 (direct deps) | removed, use `arrow` re-exports |

The direct `arrow-array` / `arrow-schema` deps are dropped since they pinned the Arrow version in three separate places and the `arrow` crate already re-exports both.

## API changes these releases required

- `parquet`: `get_column_writers` was deprecated in 57 in favour of `ArrowRowGroupWriterFactory`. The factory borrows a live `SerializedFileWriter`, so the writer is now built before the row-group stream and moved into the blocking writer task, and row groups are `enumerate()`d for the index the factory needs. That accounts for most of the churn in `parquet.rs` — the data path itself is unchanged.
- `parquet`: `set_max_row_group_size` → `set_max_row_group_row_count(Some(n))`, same semantics.
- `object_store`: `put` / `get` moved onto the `ObjectStoreExt` trait.

## Output unchanged

Arrow 58 added native `GEOMETRY` / `GEOGRAPHY` logical types, so I checked this explicitly: geometry fields carry no `ARROW:extension:name` metadata, and a generated `zone.parquet` still writes `z_boundary` as plain `optional binary`.
